### PR TITLE
Make API classmethods protected

### DIFF
--- a/exoscale/api/dns.py
+++ b/exoscale/api/dns.py
@@ -48,7 +48,7 @@ class Domain(Resource):
     unicode_name = attr.ib(repr=False)
 
     @classmethod
-    def from_cs(cls, dns, res):
+    def _from_cs(cls, dns, res):
         return cls(
             dns, res, id=res["id"], name=res["name"], unicode_name=res["unicodename"]
         )
@@ -69,7 +69,7 @@ class Domain(Resource):
         try:
             _list = self.dns.cs.listDnsDomainRecords(id=self.id, fetch_list=True)
             for i in _list:
-                yield DomainRecord.from_cs(self.dns, domain=self, res=i)
+                yield DomainRecord._from_cs(self.dns, domain=self, res=i)
         except CloudStackApiException as e:
             raise APIException(e.error["errortext"], e.error)
 
@@ -153,7 +153,7 @@ class DomainRecord(Resource):
     ttl = attr.ib(default=3600, repr=False)
 
     @classmethod
-    def from_cs(cls, dns, res, domain):
+    def _from_cs(cls, dns, res, domain):
         return cls(
             dns,
             res,
@@ -272,7 +272,7 @@ class DnsAPI(API):
         except CloudStackApiException as e:
             raise APIException(e.error["errortext"], e.error)
 
-        return Domain.from_cs(self, res["dnsdomain"])
+        return Domain._from_cs(self, res["dnsdomain"])
 
     def list_domains(self):
         """
@@ -286,7 +286,7 @@ class DnsAPI(API):
             _list = self.cs.listDnsDomains(fetch_list=True)
 
             for i in _list:
-                yield Domain.from_cs(self, i)
+                yield Domain._from_cs(self, i)
         except CloudStackApiException as e:
             raise APIException(e.error["errortext"], e.error)
 

--- a/exoscale/api/runstatus.py
+++ b/exoscale/api/runstatus.py
@@ -43,7 +43,7 @@ class Service(Resource):
     page = attr.ib(repr=False)
 
     @classmethod
-    def from_rs(cls, runstatus, res, page):
+    def _from_rs(cls, runstatus, res, page):
         return cls(
             runstatus, res, id=res["url"].split("/")[-1], name=res["name"], page=page
         )
@@ -139,7 +139,7 @@ class Incident(Resource):
     services = attr.ib(default=None, repr=False)
 
     @classmethod
-    def from_rs(cls, runstatus, res, page):
+    def _from_rs(cls, runstatus, res, page):
         return cls(
             runstatus,
             res,
@@ -315,7 +315,7 @@ class Maintenance(Resource):
     services = attr.ib(default=None, repr=False)
 
     @classmethod
-    def from_rs(cls, runstatus, res, page):
+    def _from_rs(cls, runstatus, res, page):
         return cls(
             runstatus,
             res,
@@ -484,7 +484,7 @@ class Page(Resource):
     time_zone = attr.ib(default=None, repr=False)
 
     @classmethod
-    def from_rs(cls, runstatus, res):
+    def _from_rs(cls, runstatus, res):
         return cls(runstatus, res, id=res["id"], name=res["subdomain"])
 
     @property
@@ -503,7 +503,7 @@ class Page(Resource):
         res = self.runstatus._get(url="/pages/{p}/services".format(p=self.name))
 
         for i in res.json().get("results", []):
-            yield Service.from_rs(self.runstatus, i, page=self)
+            yield Service._from_rs(self.runstatus, i, page=self)
 
     def add_service(self, name):
         """
@@ -536,7 +536,7 @@ class Page(Resource):
         res = self.runstatus._get(url="/pages/{p}/incidents".format(p=self.name))
 
         for i in res.json().get("results", []):
-            yield Incident.from_rs(self.runstatus, i, self)
+            yield Incident._from_rs(self.runstatus, i, self)
 
     def add_incident(self, title, description, state, status, services=None):
         """
@@ -597,7 +597,7 @@ class Page(Resource):
         res = self.runstatus._get(url="/pages/{p}/maintenances".format(p=self.name))
 
         for i in res.json().get("results", []):
-            yield Maintenance.from_rs(self.runstatus, i, self)
+            yield Maintenance._from_rs(self.runstatus, i, self)
 
     def add_maintenance(self, title, description, start_date, end_date, services=None):
         """
@@ -827,7 +827,7 @@ class RunstatusAPI(API):
 
         res = self._post(url="/pages", json={"name": name, "subdomain": name})
 
-        return Page.from_rs(self, res.json())
+        return Page._from_rs(self, res.json())
 
     def list_pages(self):
         """
@@ -840,7 +840,7 @@ class RunstatusAPI(API):
         res = self._get(url="/pages")
 
         for i in res.json().get("results", []):
-            yield Page.from_rs(self, i)
+            yield Page._from_rs(self, i)
 
     def get_page(self, name=None, id=None):
         """

--- a/exoscale/api/storage.py
+++ b/exoscale/api/storage.py
@@ -46,7 +46,7 @@ class CORSRule(Resource):
     max_age_seconds = attr.ib(default=None, repr=False)
 
     @classmethod
-    def from_s3(cls, res):
+    def _from_s3(cls, res):
         return cls(
             res,
             allowed_headers=res["AllowedHeaders"],
@@ -104,20 +104,20 @@ class AccessControlPolicy(Resource):
     write_acp = attr.ib(default=None, repr=False)
 
     @classmethod
-    def from_s3(cls, res):
+    def _from_s3(cls, res):
         acp = cls(res, owner=res["Owner"]["ID"])
 
         for i in res["Grants"]:
             if i["Permission"] == "FULL_CONTROL":
-                acp.full_control = acp._grantee_from_s3(i["Grantee"])
+                acp.full_control = acp._grantee__from_s3(i["Grantee"])
             if i["Permission"] == "READ":
-                acp.read = acp._grantee_from_s3(i["Grantee"])
+                acp.read = acp._grantee__from_s3(i["Grantee"])
             if i["Permission"] == "WRITE":
-                acp.write = acp._grantee_from_s3(i["Grantee"])
+                acp.write = acp._grantee__from_s3(i["Grantee"])
             if i["Permission"] == "READ_ACP":
-                acp.read_acp = acp._grantee_from_s3(i["Grantee"])
+                acp.read_acp = acp._grantee__from_s3(i["Grantee"])
             if i["Permission"] == "WRITE_ACP":
-                acp.write_acp = acp._grantee_from_s3(i["Grantee"])
+                acp.write_acp = acp._grantee__from_s3(i["Grantee"])
 
         return acp
 
@@ -166,7 +166,7 @@ class AccessControlPolicy(Resource):
 
         return acp
 
-    def _grantee_from_s3(self, grantee):
+    def _grantee__from_s3(self, grantee):
         """
         Convert an AWS S3 Access Control Policy grantee to AccessControlPolicy class
         format.
@@ -321,7 +321,7 @@ class BucketFile(Resource):
             raise APIException(e)
 
         res.pop("ResponseMetadata")
-        return AccessControlPolicy.from_s3(res)
+        return AccessControlPolicy._from_s3(res)
 
     @property
     def metadata(self):
@@ -447,7 +447,7 @@ class Bucket(Resource):
             raise APIException(e)
 
         res.pop("ResponseMetadata")
-        return AccessControlPolicy.from_s3(res)
+        return AccessControlPolicy._from_s3(res)
 
     @property
     def cors(self):
@@ -465,7 +465,7 @@ class Bucket(Resource):
         try:
             res = self.storage.boto.get_bucket_cors(Bucket=self.name)
             for i in res["CORSRules"]:
-                yield CORSRule.from_s3(i)
+                yield CORSRule._from_s3(i)
         except Exception as e:
             raise APIException(e)
 

--- a/exoscale/api/storage.py
+++ b/exoscale/api/storage.py
@@ -56,7 +56,7 @@ class CORSRule(Resource):
             max_age_seconds=res.get("MaxAgeSeconds", None),
         )
 
-    def to_s3(self):
+    def _to_s3(self):
         """
         Serialize a CORSRule class instance to the AWS S3 CORS rule format.
 
@@ -109,19 +109,19 @@ class AccessControlPolicy(Resource):
 
         for i in res["Grants"]:
             if i["Permission"] == "FULL_CONTROL":
-                acp.full_control = acp._grantee__from_s3(i["Grantee"])
+                acp.full_control = acp._grantee_from_s3(i["Grantee"])
             if i["Permission"] == "READ":
-                acp.read = acp._grantee__from_s3(i["Grantee"])
+                acp.read = acp._grantee_from_s3(i["Grantee"])
             if i["Permission"] == "WRITE":
-                acp.write = acp._grantee__from_s3(i["Grantee"])
+                acp.write = acp._grantee_from_s3(i["Grantee"])
             if i["Permission"] == "READ_ACP":
-                acp.read_acp = acp._grantee__from_s3(i["Grantee"])
+                acp.read_acp = acp._grantee_from_s3(i["Grantee"])
             if i["Permission"] == "WRITE_ACP":
-                acp.write_acp = acp._grantee__from_s3(i["Grantee"])
+                acp.write_acp = acp._grantee_from_s3(i["Grantee"])
 
         return acp
 
-    def to_s3(self):
+    def _to_s3(self):
         """
         Serialize an AccessControlPolicy class instance to the AWS S3 Access Control
         Policy format.
@@ -166,7 +166,7 @@ class AccessControlPolicy(Resource):
 
         return acp
 
-    def _grantee__from_s3(self, grantee):
+    def _grantee_from_s3(self, grantee):
         """
         Convert an AWS S3 Access Control Policy grantee to AccessControlPolicy class
         format.
@@ -389,7 +389,7 @@ class BucketFile(Resource):
                 res = self.storage.boto.put_object_acl(
                     Bucket=self.bucket.name,
                     Key=self.path,
-                    AccessControlPolicy=acp.to_s3(),
+                    AccessControlPolicy=acp._to_s3(),
                 )
         except Exception as e:
             raise APIException(e)
@@ -660,7 +660,7 @@ class Bucket(Resource):
                 res = self.storage.boto.put_bucket_acl(Bucket=self.name, ACL=acl)
             else:
                 res = self.storage.boto.put_bucket_acl(
-                    Bucket=self.name, AccessControlPolicy=acp.to_s3()
+                    Bucket=self.name, AccessControlPolicy=acp._to_s3()
                 )
         except Exception as e:
             raise APIException(e)
@@ -679,7 +679,7 @@ class Bucket(Resource):
         try:
             res = self.storage.boto.put_bucket_cors(
                 Bucket=self.name,
-                CORSConfiguration={"CORSRules": list(r.to_s3() for r in rules)},
+                CORSConfiguration={"CORSRules": list(r._to_s3() for r in rules)},
             )
         except Exception as e:
             raise APIException(e)

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -23,7 +23,7 @@ class TestCompute:
         exo.compute.cs.deleteAffinityGroup(id=anti_affinity_group.id)
 
     def test_list_anti_affinity_groups(self, exo, aag):
-        anti_affinity_group = AntiAffinityGroup.from_cs(exo.compute, aag())
+        anti_affinity_group = AntiAffinityGroup._from_cs(exo.compute, aag())
 
         anti_affinity_groups = list(exo.compute.list_anti_affinity_groups())
         # We cannot guarantee that there will be only our resources,
@@ -31,8 +31,8 @@ class TestCompute:
         assert len(anti_affinity_groups) >= 1
 
     def test_get_anti_affinity_group(self, exo, aag):
-        anti_affinity_group1 = AntiAffinityGroup.from_cs(exo.compute, aag())
-        anti_affinity_group2 = AntiAffinityGroup.from_cs(exo.compute, aag())
+        anti_affinity_group1 = AntiAffinityGroup._from_cs(exo.compute, aag())
+        anti_affinity_group2 = AntiAffinityGroup._from_cs(exo.compute, aag())
 
         anti_affinity_group = exo.compute.get_anti_affinity_group(
             id=anti_affinity_group1.id
@@ -59,7 +59,7 @@ class TestCompute:
     ### Elastic IP
 
     def test_create_elastic_ip(self, exo, zone):
-        zone_gva2 = Zone.from_cs(zone("ch-gva-2"))
+        zone_gva2 = Zone._from_cs(zone("ch-gva-2"))
         healthcheck_mode = "http"
         healthcheck_port = 80
         healthcheck_path = "/health"
@@ -92,8 +92,8 @@ class TestCompute:
         exo.compute.cs.disassociateIpAddress(id=elastic_ip.id)
 
     def test_list_elastic_ips(self, exo, zone, eip):
-        zone_gva2 = Zone.from_cs(zone("ch-gva-2"))
-        zone_fra1 = Zone.from_cs(zone("de-fra-1"))
+        zone_gva2 = Zone._from_cs(zone("ch-gva-2"))
+        zone_fra1 = Zone._from_cs(zone("de-fra-1"))
         elastic_ip1 = eip(zone_id=zone_gva2.id)
         elastic_ip2 = eip(zone_id=zone_fra1.id)
 
@@ -108,8 +108,8 @@ class TestCompute:
         assert len(elastic_ips) >= 1
 
     def test_get_elastic_ip(self, exo, zone, eip):
-        elastic_ip1 = ElasticIP.from_cs(exo.compute, eip())
-        elastic_ip2 = ElasticIP.from_cs(exo.compute, eip())
+        elastic_ip1 = ElasticIP._from_cs(exo.compute, eip())
+        elastic_ip2 = ElasticIP._from_cs(exo.compute, eip())
 
         elastic_ip = exo.compute.get_elastic_ip(id=elastic_ip1.id)
         assert elastic_ip.id == elastic_ip1.id
@@ -145,19 +145,19 @@ class TestCompute:
         test_instance_service_offering_id,
         test_instance_template_id,
     ):
-        zone_gva2 = Zone.from_cs(zone("ch-gva-2"))
+        zone_gva2 = Zone._from_cs(zone("ch-gva-2"))
         instance_name = "-".join([test_prefix, _random_str()])
-        instance_type = InstanceType.from_cs(
+        instance_type = InstanceType._from_cs(
             instance_type(id=test_instance_service_offering_id)
         )
-        template = InstanceTemplate.from_cs(
+        template = InstanceTemplate._from_cs(
             exo.compute, instance_template(id=test_instance_template_id)
         )
-        anti_affinity_group = AntiAffinityGroup.from_cs(exo.compute, aag())
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        security_group1 = SecurityGroup.from_cs(exo.compute, sg())
-        security_group2 = SecurityGroup.from_cs(exo.compute, sg())
-        ssh_key = SSHKey.from_cs(exo.compute, sshkey())
+        anti_affinity_group = AntiAffinityGroup._from_cs(exo.compute, aag())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        security_group1 = SecurityGroup._from_cs(exo.compute, sg())
+        security_group2 = SecurityGroup._from_cs(exo.compute, sg())
+        ssh_key = SSHKey._from_cs(exo.compute, sshkey())
 
         instance = exo.compute.create_instance(
             name=instance_name,
@@ -193,11 +193,11 @@ class TestCompute:
         exo.compute.cs.destroyVirtualMachine(id=instance.id)
 
     def test_list_instances(self, exo, zone, privnet, instance):
-        zone_gva2 = Zone.from_cs(zone("ch-gva-2"))
-        zone_fra1 = Zone.from_cs(zone("de-fra-1"))
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        instance1 = Instance.from_cs(exo.compute, instance(zone_id=zone_gva2.id))
-        instance2 = Instance.from_cs(exo.compute, instance(zone_id=zone_fra1.id))
+        zone_gva2 = Zone._from_cs(zone("ch-gva-2"))
+        zone_fra1 = Zone._from_cs(zone("de-fra-1"))
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        instance1 = Instance._from_cs(exo.compute, instance(zone_id=zone_gva2.id))
+        instance2 = Instance._from_cs(exo.compute, instance(zone_id=zone_fra1.id))
 
         instances = list(exo.compute.list_instances(zone=zone_gva2))
         # We cannot guarantee that there will be only our resources,
@@ -225,8 +225,8 @@ class TestCompute:
             )
 
     def test_get_instance(self, exo, privnet, instance):
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        instance1 = Instance.from_cs(exo.compute, instance())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        instance1 = Instance._from_cs(exo.compute, instance())
 
         instance = exo.compute.get_instance(id=instance1.id)
         assert instance.id == instance1.id
@@ -246,7 +246,7 @@ class TestCompute:
     def test_list_instance_templates(
         self, exo, zone, test_instance_template_id, test_instance_template_name
     ):
-        zone_gva2 = Zone.from_cs(zone("ch-gva-2"))
+        zone_gva2 = Zone._from_cs(zone("ch-gva-2"))
 
         instance_templates = list(exo.compute.list_instance_templates(zone=zone_gva2))
         assert len(instance_templates) > 10
@@ -320,7 +320,7 @@ class TestCompute:
 
     def test_create_private_network(self, exo, zone, test_prefix, test_description):
         private_network_name = "-".join([test_prefix, _random_str()])
-        zone_gva2 = Zone.from_cs(zone("ch-gva-2"))
+        zone_gva2 = Zone._from_cs(zone("ch-gva-2"))
         start_ip = "192.168.1.10"
         end_ip = "192.168.1.100"
         netmask = "255.255.255.0"
@@ -344,12 +344,12 @@ class TestCompute:
         exo.compute.cs.deleteNetwork(id=private_network.id)
 
     def test_list_private_networks(self, exo, zone, privnet):
-        zone_gva2 = Zone.from_cs(zone("ch-gva-2"))
-        zone_fra1 = Zone.from_cs(zone("de-fra-1"))
-        private_network1 = PrivateNetwork.from_cs(
+        zone_gva2 = Zone._from_cs(zone("ch-gva-2"))
+        zone_fra1 = Zone._from_cs(zone("de-fra-1"))
+        private_network1 = PrivateNetwork._from_cs(
             exo.compute, privnet(zone_id=zone_gva2.id)
         )
-        private_network2 = PrivateNetwork.from_cs(
+        private_network2 = PrivateNetwork._from_cs(
             exo.compute, privnet(zone_id=zone_fra1.id)
         )
 
@@ -371,7 +371,7 @@ class TestCompute:
             assert p.zone.name == private_network1.zone.name
 
     def test_get_private_network(self, exo, privnet):
-        private_network1 = PrivateNetwork.from_cs(exo.compute, privnet())
+        private_network1 = PrivateNetwork._from_cs(exo.compute, privnet())
 
         private_network = exo.compute.get_private_network(id=private_network1.id)
         assert private_network.id == private_network1.id
@@ -399,8 +399,8 @@ class TestCompute:
         exo.compute.cs.deleteSecurityGroup(id=security_group.id)
 
     def test_list_security_groups(self, exo, sg):
-        security_group1 = SecurityGroup.from_cs(exo.compute, sg())
-        security_group2 = SecurityGroup.from_cs(exo.compute, sg())
+        security_group1 = SecurityGroup._from_cs(exo.compute, sg())
+        security_group2 = SecurityGroup._from_cs(exo.compute, sg())
 
         security_groups = list(exo.compute.list_security_groups())
         # We cannot guarantee that there will be only our resources,
@@ -408,8 +408,8 @@ class TestCompute:
         assert len(security_groups) >= 2
 
     def test_get_security_group(self, exo, sg):
-        security_group1 = SecurityGroup.from_cs(exo.compute, sg())
-        security_group2 = SecurityGroup.from_cs(exo.compute, sg())
+        security_group1 = SecurityGroup._from_cs(exo.compute, sg())
+        security_group2 = SecurityGroup._from_cs(exo.compute, sg())
 
         security_group = exo.compute.get_security_group(id=security_group1.id)
         assert security_group.name == security_group1.name
@@ -463,7 +463,7 @@ class TestCompute:
         exo.compute.cs.deleteSSHKeyPair(name=ssh_key.name)
 
     def test_list_ssh_keys(self, exo, sshkey):
-        ssh_key = SSHKey.from_cs(exo.compute, sshkey())
+        ssh_key = SSHKey._from_cs(exo.compute, sshkey())
 
         ssh_keys = list(exo.compute.list_ssh_keys())
         # We cannot guarantee that there will be only our resources,
@@ -471,7 +471,7 @@ class TestCompute:
         assert len(ssh_keys) >= 1
 
     def test_get_ssh_key(self, exo, sshkey):
-        ssh_key = SSHKey.from_cs(exo.compute, sshkey())
+        ssh_key = SSHKey._from_cs(exo.compute, sshkey())
 
         ssh_key = exo.compute.get_ssh_key(name=ssh_key.name)
         assert ssh_key.name == ssh_key.name

--- a/tests/test_compute_anti_affinity_group.py
+++ b/tests/test_compute_anti_affinity_group.py
@@ -7,7 +7,7 @@ from exoscale.api.compute import *
 
 class TestComputeAntiAffinityGroup:
     def test_delete(self, exo, aag):
-        anti_affinity_group = AntiAffinityGroup.from_cs(
+        anti_affinity_group = AntiAffinityGroup._from_cs(
             exo.compute, aag(teardown=False)
         )
         anti_affinity_group_name = anti_affinity_group.name
@@ -21,8 +21,8 @@ class TestComputeAntiAffinityGroup:
         assert len(res) == 0
 
     def test_properties(self, exo, aag, instance):
-        anti_affinity_group = AntiAffinityGroup.from_cs(exo.compute, aag())
-        instance = Instance.from_cs(
+        anti_affinity_group = AntiAffinityGroup._from_cs(exo.compute, aag())
+        instance = Instance._from_cs(
             exo.compute, instance(anti_affinity_groups=[anti_affinity_group.id])
         )
 

--- a/tests/test_compute_elastic_ip.py
+++ b/tests/test_compute_elastic_ip.py
@@ -7,8 +7,8 @@ from exoscale.api.compute import *
 
 class TestComputeElasticIP:
     def test_attach_instance(self, exo, eip, instance):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
-        instance = Instance.from_cs(exo.compute, instance())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
+        instance = Instance._from_cs(exo.compute, instance())
 
         elastic_ip.attach_instance(instance)
 
@@ -19,8 +19,8 @@ class TestComputeElasticIP:
         )
 
     def test_detach_instance(self, exo, eip, instance):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
-        instance = Instance.from_cs(exo.compute, instance())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.listNics(virtualmachineid=instance.id, fetch_list=True)
         exo.compute.cs.addIpToNic(
@@ -39,7 +39,7 @@ class TestComputeElasticIP:
         assert "secondaryip" not in instance._default_nic(res)
 
     def test_set_reverse_dns(self, exo, eip, test_reverse_dns):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
 
         elastic_ip.set_reverse_dns(record=test_reverse_dns)
 
@@ -47,7 +47,7 @@ class TestComputeElasticIP:
         assert res["publicipaddress"]["reversedns"][0]["domainname"] == test_reverse_dns
 
     def test_unset_reverse_dns(self, exo, eip, test_reverse_dns):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
 
         res = exo.compute.cs.updateReverseDnsForPublicIpAddress(
             id=elastic_ip.id, domainname=test_reverse_dns
@@ -60,7 +60,7 @@ class TestComputeElasticIP:
         assert len(res["publicipaddress"]["reversedns"]) == 0
 
     def test_update(self, exo, eip):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
         healthcheck_mode = "http"
         healthcheck_port = 80
         healthcheck_path = "/test"
@@ -97,9 +97,9 @@ class TestComputeElasticIP:
         assert elastic_ip.healthcheck_strikes_fail == healthcheck_strikes_fail
 
     def test_delete(self, exo, eip, instance):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip(teardown=False))
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip(teardown=False))
         elastic_ip_id = elastic_ip.id
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.listNics(virtualmachineid=instance.id, fetch_list=True)
         exo.compute.cs.addIpToNic(
@@ -113,8 +113,8 @@ class TestComputeElasticIP:
         assert len(res) == 0
 
     def test_properties(self, exo, eip, instance, test_reverse_dns):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
-        instance = Instance.from_cs(exo.compute, instance())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
+        instance = Instance._from_cs(exo.compute, instance())
 
         instance_nics = exo.compute.cs.listNics(
             virtualmachineid=instance.id, fetch_list=True

--- a/tests/test_compute_instance.py
+++ b/tests/test_compute_instance.py
@@ -7,9 +7,9 @@ from exoscale.api.compute import *
 
 class TestComputeInstance:
     def test_update(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance(start=False))
+        instance = Instance._from_cs(exo.compute, instance(start=False))
         name_edited = instance.name + "-edited"
-        security_group_default = SecurityGroup.from_cs(
+        security_group_default = SecurityGroup._from_cs(
             exo.compute,
             exo.compute.cs.listSecurityGroups(
                 securitygroupname="default", fetch_list=True
@@ -28,8 +28,8 @@ class TestComputeInstance:
         assert res["id"] == security_group_default.id
 
     def test_scale(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance(start=False))
-        instance_type_small = InstanceType.from_cs(
+        instance = Instance._from_cs(exo.compute, instance(start=False))
+        instance_type_small = InstanceType._from_cs(
             exo.compute.cs.listServiceOfferings(name="small", fetch_list=True)[0]
         )
 
@@ -39,7 +39,7 @@ class TestComputeInstance:
         assert res["serviceofferingid"] == instance_type_small.id
 
     def test_start(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance(start=False))
+        instance = Instance._from_cs(exo.compute, instance(start=False))
 
         instance.start()
 
@@ -47,7 +47,7 @@ class TestComputeInstance:
         assert res["state"].lower() in {"starting", "running"}
 
     def test_stop(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         instance.stop()
 
@@ -55,7 +55,7 @@ class TestComputeInstance:
         assert res["state"].lower() in ["stopping", "stopped"]
 
     def test_reboot(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         instance.reboot()
 
@@ -63,7 +63,7 @@ class TestComputeInstance:
         assert res["state"].lower() in ["starting", "running"]
 
     def test_resize_volume(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance(start=False))
+        instance = Instance._from_cs(exo.compute, instance(start=False))
 
         instance.resize_volume(size=20)
 
@@ -72,7 +72,7 @@ class TestComputeInstance:
         assert instance.volume_size == 21474836480
 
     def test_snapshot_volume(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         snapshot = instance.snapshot_volume()
         assert snapshot.id != ""
@@ -80,8 +80,8 @@ class TestComputeInstance:
         assert snapshot.size > 0
 
     def test_attach_elastic_ip(self, exo, eip, instance):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
-        instance = Instance.from_cs(exo.compute, instance())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
+        instance = Instance._from_cs(exo.compute, instance())
 
         instance.attach_elastic_ip(elastic_ip=elastic_ip)
 
@@ -92,8 +92,8 @@ class TestComputeInstance:
             assert nic["secondaryip"][0]["ipaddress"] == elastic_ip.address
 
     def test_detach_elastic_ip(self, exo, eip, instance):
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
-        instance = Instance.from_cs(exo.compute, instance())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
+        instance = Instance._from_cs(exo.compute, instance())
 
         instance.attach_elastic_ip(elastic_ip=elastic_ip)
 
@@ -112,8 +112,8 @@ class TestComputeInstance:
             assert "secondaryip" not in nic
 
     def test_attach_private_network(self, exo, privnet, instance):
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        instance = Instance.from_cs(exo.compute, instance())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        instance = Instance._from_cs(exo.compute, instance())
 
         instance.attach_private_network(private_network=private_network)
 
@@ -128,8 +128,8 @@ class TestComputeInstance:
         )
 
     def test_detach_private_network(self, exo, privnet, instance):
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        instance = Instance.from_cs(exo.compute, instance())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.addNicToVirtualMachine(
             virtualmachineid=instance.id, networkid=private_network.id
@@ -149,7 +149,7 @@ class TestComputeInstance:
         assert len(res) == 0
 
     def test_set_reverse_dns(self, exo, instance, test_reverse_dns):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         instance.set_reverse_dns(record=test_reverse_dns)
 
@@ -160,7 +160,7 @@ class TestComputeInstance:
         )
 
     def test_unset_reverse_dns(self, exo, instance, test_reverse_dns):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.updateReverseDnsForVirtualMachine(
             id=instance.id, domainname=test_reverse_dns
@@ -176,7 +176,7 @@ class TestComputeInstance:
         assert len(res["virtualmachine"]["nic"][0]["reversedns"]) == 0
 
     def test_delete(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance(teardown=False))
+        instance = Instance._from_cs(exo.compute, instance(teardown=False))
         instance_name = instance.name
 
         instance.delete()
@@ -186,11 +186,11 @@ class TestComputeInstance:
         assert len(res) == 0
 
     def test_properties(self, exo, aag, sg, privnet, eip, instance, test_reverse_dns):
-        anti_affinity_group = AntiAffinityGroup.from_cs(exo.compute, aag())
-        security_group = SecurityGroup.from_cs(exo.compute, sg())
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        elastic_ip = ElasticIP.from_cs(exo.compute, eip())
-        instance = Instance.from_cs(
+        anti_affinity_group = AntiAffinityGroup._from_cs(exo.compute, aag())
+        security_group = SecurityGroup._from_cs(exo.compute, sg())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        elastic_ip = ElasticIP._from_cs(exo.compute, eip())
+        instance = Instance._from_cs(
             exo.compute,
             instance(
                 anti_affinity_groups=[anti_affinity_group.id],

--- a/tests/test_compute_instance_volume_snapshot.py
+++ b/tests/test_compute_instance_volume_snapshot.py
@@ -7,10 +7,10 @@ from exoscale.api.compute import *
 
 class TestComputeInstanceVolumeSnapshot:
     def test_revert(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.createSnapshot(volumeid=instance.volume_id)
-        snapshot = InstanceVolumeSnapshot.from_cs(exo.compute, res["snapshot"])
+        snapshot = InstanceVolumeSnapshot._from_cs(exo.compute, res["snapshot"])
 
         res = exo.compute.cs.stopVirtualMachine(id=instance.id)
         assert res["virtualmachine"]["state"].lower() in ["stopping", "stopped"]
@@ -20,10 +20,10 @@ class TestComputeInstanceVolumeSnapshot:
         # so we'll consider that no exception is an OK -- no news is good news!
 
     def test_delete(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.createSnapshot(volumeid=instance.volume_id)
-        snapshot = InstanceVolumeSnapshot.from_cs(exo.compute, res["snapshot"])
+        snapshot = InstanceVolumeSnapshot._from_cs(exo.compute, res["snapshot"])
 
         snapshot.delete()
         assert snapshot.id is None
@@ -32,10 +32,10 @@ class TestComputeInstanceVolumeSnapshot:
         assert len(res) == 0
 
     def test_properties(self, exo, instance):
-        instance = Instance.from_cs(exo.compute, instance())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.createSnapshot(volumeid=instance.volume_id)
-        instance_volume_snapshot = InstanceVolumeSnapshot.from_cs(
+        instance_volume_snapshot = InstanceVolumeSnapshot._from_cs(
             exo.compute, res["snapshot"]
         )
         assert instance_volume_snapshot.state == "backedup"

--- a/tests/test_compute_private_network.py
+++ b/tests/test_compute_private_network.py
@@ -7,8 +7,8 @@ from exoscale.api.compute import *
 
 class TestComputePrivateNetwork:
     def test_attach_instance(self, exo, privnet, instance):
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        instance = Instance.from_cs(exo.compute, instance())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        instance = Instance._from_cs(exo.compute, instance())
 
         private_network.attach_instance(instance)
 
@@ -27,8 +27,8 @@ class TestComputePrivateNetwork:
             )
 
     def test_detach_instance(self, exo, privnet, instance):
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        instance = Instance.from_cs(exo.compute, instance())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        instance = Instance._from_cs(exo.compute, instance())
 
         exo.compute.cs.addNicToVirtualMachine(
             virtualmachineid=instance.id, networkid=private_network.id
@@ -48,7 +48,7 @@ class TestComputePrivateNetwork:
         assert len(res) == 0
 
     def test_update(self, exo, privnet):
-        private_network = PrivateNetwork.from_cs(
+        private_network = PrivateNetwork._from_cs(
             exo.compute,
             privnet(start_ip="10.0.0.10", end_ip="10.0.0.50", netmask="255.255.255.0"),
         )
@@ -79,7 +79,7 @@ class TestComputePrivateNetwork:
         assert private_network.netmask == netmask_edited
 
     def test_delete(self, exo, privnet):
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet(teardown=False))
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet(teardown=False))
         private_network_id = private_network.id
 
         private_network.delete()
@@ -92,8 +92,8 @@ class TestComputePrivateNetwork:
         assert "does not exist" in excinfo.value.error["errortext"]
 
     def test_properties(self, exo, privnet, instance):
-        private_network = PrivateNetwork.from_cs(exo.compute, privnet())
-        instance = Instance.from_cs(exo.compute, instance())
+        private_network = PrivateNetwork._from_cs(exo.compute, privnet())
+        instance = Instance._from_cs(exo.compute, instance())
 
         res = exo.compute.cs.addNicToVirtualMachine(
             virtualmachineid=instance.id, networkid=private_network.id

--- a/tests/test_compute_security_group.py
+++ b/tests/test_compute_security_group.py
@@ -7,14 +7,14 @@ from exoscale.api.compute import *
 
 class TestComputeSecurityGroup:
     def test_add_rule(self, exo, sg, test_description):
-        security_group = SecurityGroup.from_cs(exo.compute, sg())
+        security_group = SecurityGroup._from_cs(exo.compute, sg())
         test_network_cidr = "1.1.1.1/32"
         test_port_ingress = "80-81"
         test_protocol_ingress = "tcp"
         test_port_egress = "53"
         test_protocol_egress = "udp"
 
-        security_group_default = SecurityGroup.from_cs(
+        security_group_default = SecurityGroup._from_cs(
             exo.compute,
             exo.compute.cs.listSecurityGroups(
                 securitygroupname="default", fetch_list=True
@@ -56,7 +56,7 @@ class TestComputeSecurityGroup:
         assert str(res[0]["egressrule"][0]["endport"]) == test_port_egress
 
     def test_delete(self, exo, sg):
-        security_group = SecurityGroup.from_cs(exo.compute, sg(teardown=False))
+        security_group = SecurityGroup._from_cs(exo.compute, sg(teardown=False))
         security_group_name = security_group.name
 
         security_group.delete()
@@ -68,8 +68,8 @@ class TestComputeSecurityGroup:
         assert len(res) == 0
 
     def test_properties(self, exo, sg):
-        security_group = SecurityGroup.from_cs(exo.compute, sg())
-        security_group_default = SecurityGroup.from_cs(
+        security_group = SecurityGroup._from_cs(exo.compute, sg())
+        security_group_default = SecurityGroup._from_cs(
             exo.compute,
             exo.compute.cs.listSecurityGroups(
                 securitygroupname="default", fetch_list=True

--- a/tests/test_compute_security_group_rule.py
+++ b/tests/test_compute_security_group_rule.py
@@ -7,7 +7,7 @@ from exoscale.api.compute import *
 
 class TestComputeSecurityGroupRule:
     def test_delete(self, exo, sg):
-        security_group = SecurityGroup.from_cs(exo.compute, sg())
+        security_group = SecurityGroup._from_cs(exo.compute, sg())
 
         rule1 = exo.compute.cs.authorizeSecurityGroupIngress(
             securitygroupid=security_group.id,
@@ -25,10 +25,10 @@ class TestComputeSecurityGroupRule:
         )["securitygroup"]["egressrule"][0]
 
         res = exo.compute.cs.listSecurityGroups(id=security_group.id, fetch_list=True)
-        SecurityGroupRule.from_cs(
+        SecurityGroupRule._from_cs(
             compute=exo.compute, type="ingress", res=res[0]["ingressrule"][0]
         ).delete()
-        SecurityGroupRule.from_cs(
+        SecurityGroupRule._from_cs(
             compute=exo.compute, type="egress", res=res[0]["egressrule"][0]
         ).delete()
 

--- a/tests/test_compute_ssh_key.py
+++ b/tests/test_compute_ssh_key.py
@@ -7,7 +7,7 @@ from exoscale.api.compute import *
 
 class TestComputeSSHKey:
     def test_delete(self, exo, sshkey):
-        ssh_key = SSHKey.from_cs(exo.compute, sshkey(teardown=False))
+        ssh_key = SSHKey._from_cs(exo.compute, sshkey(teardown=False))
         ssh_key_name = ssh_key.name
 
         ssh_key.delete()

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -19,7 +19,7 @@ class TestDNS:
         exo.dns.cs.deleteDnsDomain(id=domain.id)
 
     def test_list_domains(self, exo, domain):
-        domain = Domain.from_cs(exo.dns, domain())
+        domain = Domain._from_cs(exo.dns, domain())
 
         domains = list(exo.dns.list_domains())
         # We cannot guarantee that there will be only our resources,
@@ -27,7 +27,7 @@ class TestDNS:
         assert len(domains) >= 1
 
     def test_get_domain(self, exo, domain):
-        domain1 = Domain.from_cs(exo.dns, domain())
+        domain1 = Domain._from_cs(exo.dns, domain())
 
         domain = exo.dns.get_domain(id=domain1.id)
         assert domain.id == domain1.id

--- a/tests/test_dns_domain.py
+++ b/tests/test_dns_domain.py
@@ -8,7 +8,7 @@ from exoscale.api.dns import *
 
 class TestDNSDomain:
     def test_add_record(self, exo, domain):
-        domain = Domain.from_cs(exo.dns, domain())
+        domain = Domain._from_cs(exo.dns, domain())
         domain_record_name = "test-python-exoscale"
         domain_record_type = "MX"
         domain_record_content = "mx1.example.net"
@@ -34,7 +34,7 @@ class TestDNSDomain:
             assert record["ttl"] == domain_record_ttl
 
     def test_delete(self, exo, domain):
-        domain = Domain.from_cs(exo.dns, domain(teardown=False))
+        domain = Domain._from_cs(exo.dns, domain(teardown=False))
         domain_id = domain.id
 
         domain.delete()
@@ -45,7 +45,7 @@ class TestDNSDomain:
             assert i["id"] != domain_id
 
     def test_properties(self, exo, domain):
-        domain = Domain.from_cs(exo.dns, domain())
+        domain = Domain._from_cs(exo.dns, domain())
         domain_record_name = "test-python-exoscale"
         domain_record_type = "A"
         domain_record_content = "1.2.3.4"

--- a/tests/test_dns_domain_record.py
+++ b/tests/test_dns_domain_record.py
@@ -8,7 +8,7 @@ from exoscale.api.dns import *
 
 class TestDNSDomainRecord:
     def test_update(self, exo, domain):
-        domain = Domain.from_cs(exo.dns, domain())
+        domain = Domain._from_cs(exo.dns, domain())
         domain_record_name = "test-python-exoscale"
         domain_record_name_edited = "test-python-exoscale-edited"
         domain_record_type = "MX"
@@ -33,7 +33,7 @@ class TestDNSDomainRecord:
             if r["name"] == "":
                 continue
 
-            domain_record = DomainRecord.from_cs(exo.dns, r, domain)
+            domain_record = DomainRecord._from_cs(exo.dns, r, domain)
 
             domain_record.update(
                 name=domain_record_name_edited,
@@ -52,7 +52,7 @@ class TestDNSDomainRecord:
             assert r["ttl"] == domain_record_ttl_edited
 
     def test_delete(self, exo, domain):
-        domain = Domain.from_cs(exo.dns, domain())
+        domain = Domain._from_cs(exo.dns, domain())
         domain_record_name = "test-python-exoscale"
         domain_record_type = "MX"
         domain_record_content = "mx1.example.net"
@@ -73,7 +73,7 @@ class TestDNSDomainRecord:
             if r["name"] == "":
                 continue
 
-            domain_record = DomainRecord.from_cs(exo.dns, r, domain)
+            domain_record = DomainRecord._from_cs(exo.dns, r, domain)
 
             domain_record.delete()
 

--- a/tests/test_runstatus.py
+++ b/tests/test_runstatus.py
@@ -19,7 +19,7 @@ class TestRunstatus:
         exo.runstatus._delete(url="/pages/{p}".format(p=page_name))
 
     def test_list_pages(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
 
         pages = list(exo.runstatus.list_pages())
         # We cannot guarantee that there will be only our resources,
@@ -27,7 +27,7 @@ class TestRunstatus:
         assert len(pages) >= 1
 
     def test_get_page(self, exo, runstatus_page):
-        page1 = Page.from_rs(exo.runstatus, runstatus_page())
+        page1 = Page._from_rs(exo.runstatus, runstatus_page())
 
         page = exo.runstatus.get_page(name=page1.name)
         assert page.name == page1.name

--- a/tests/test_runstatus_page.py
+++ b/tests/test_runstatus_page.py
@@ -9,7 +9,7 @@ from .conftest import _random_str
 
 class TestRunstatusPage:
     def test_add_service(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
 
         page.add_service(name="test")
 
@@ -18,7 +18,7 @@ class TestRunstatusPage:
         assert res["results"][0]["name"] == "test"
 
     def test_add_incident(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_incident_title = "Everything's on fire"
         test_incident_description = "It's fine ¯\\_(ツ)_/¯"
         test_incident_state = "major_outage"
@@ -46,7 +46,7 @@ class TestRunstatusPage:
         assert res["results"][0]["services"] == test_incident_services
 
     def test_add_maintenance(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_maintenance_title = "Database server upgrade"
         test_maintenance_description = (
             "We're upgrading the database server hardware to add more memory"
@@ -85,7 +85,7 @@ class TestRunstatusPage:
         assert res["results"][0]["services"] == [test_maintenance_service]
 
     def test_delete(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page(teardown=False))
+        page = Page._from_rs(exo.runstatus, runstatus_page(teardown=False))
 
         page.delete()
         assert page.id is None
@@ -95,7 +95,7 @@ class TestRunstatusPage:
         assert excinfo.type == ResourceNotFoundError
 
     def test_update(self, exo, runstatus_page, test_prefix):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_page_title_edited = "python-exoscale"
         test_page_default_status_message_edited = "It's all good in the hood"
         test_page_custom_domain_edited = (
@@ -121,7 +121,7 @@ class TestRunstatusPage:
         assert page.time_zone == test_page_time_zone_edited
 
     def test_properties(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_page_service_name = "python-exoscale"
         test_incident_title = "Everything's on fire"
         test_incident_description = "It's fine ¯\\_(ツ)_/¯"

--- a/tests/test_runstatus_page_incident.py
+++ b/tests/test_runstatus_page_incident.py
@@ -8,7 +8,7 @@ from datetime import timezone
 
 class TestRunstatusPageIncident:
     def test_add_event(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_incident_title = "Everything's on fire"
         test_incident_description = "It's fine ¯\\_(ツ)_/¯"
         test_incident_state = "major_outage"
@@ -32,7 +32,7 @@ class TestRunstatusPageIncident:
         )
 
         res = exo.runstatus._get(url="/pages/{p}/incidents".format(p=page.name)).json()
-        incident = Incident.from_rs(exo.runstatus, res["results"][0], page)
+        incident = Incident._from_rs(exo.runstatus, res["results"][0], page)
 
         incident.add_event(description="Hmm...", status="investigating")
         incident.add_event(description="Who did this?!", status="identified")
@@ -57,7 +57,7 @@ class TestRunstatusPageIncident:
         assert res["results"][2]["status"] == "investigating"
 
     def test_update(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_incident_description = "It's fine ¯\\_(ツ)_/¯"
         test_incident_state = "major_outage"
         test_incident_status = "identified"
@@ -83,7 +83,7 @@ class TestRunstatusPageIncident:
         )
 
         res = exo.runstatus._get(url="/pages/{p}/incidents".format(p=page.name)).json()
-        incident = Incident.from_rs(exo.runstatus, res["results"][0], page)
+        incident = Incident._from_rs(exo.runstatus, res["results"][0], page)
 
         incident.update(
             title=test_incident_title_edited, services=[test_incident_service_edited]
@@ -98,7 +98,7 @@ class TestRunstatusPageIncident:
         assert incident.services == [test_incident_service_edited]
 
     def test_close(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_incident_title = "Everything's on fire"
         test_incident_description = "It's fine ¯\\_(ツ)_/¯"
         test_incident_state = "major_outage"
@@ -122,7 +122,7 @@ class TestRunstatusPageIncident:
         )
 
         res = exo.runstatus._get(url="/pages/{p}/incidents".format(p=page.name)).json()
-        incident = Incident.from_rs(exo.runstatus, res["results"][0], page)
+        incident = Incident._from_rs(exo.runstatus, res["results"][0], page)
 
         incident.close(description="There, I fixed it")
 
@@ -135,7 +135,7 @@ class TestRunstatusPageIncident:
         assert res["results"][0]["status"] == "resolved"
 
     def test_properties(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_incident_title = "Everything's on fire"
         test_incident_description = "It's fine ¯\\_(ツ)_/¯"
         test_incident_state = "major_outage"
@@ -159,7 +159,7 @@ class TestRunstatusPageIncident:
         )
 
         res = exo.runstatus._get(url="/pages/{p}/incidents".format(p=page.name)).json()
-        incident = Incident.from_rs(exo.runstatus, res["results"][0], page)
+        incident = Incident._from_rs(exo.runstatus, res["results"][0], page)
 
         for i in [1, 2, 3]:
             exo.runstatus._post(

--- a/tests/test_runstatus_page_maintenance.py
+++ b/tests/test_runstatus_page_maintenance.py
@@ -8,7 +8,7 @@ from datetime import timezone
 
 class TestRunstatusPageMaintenance:
     def test_add_event(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_maintenance_title = "Database server upgrade"
         test_maintenance_description = (
             "We're upgrading the database server hardware to add more memory"
@@ -36,7 +36,7 @@ class TestRunstatusPageMaintenance:
         res = exo.runstatus._get(
             url="/pages/{p}/maintenances".format(p=page.name)
         ).json()
-        maintenance = Maintenance.from_rs(exo.runstatus, res["results"][0], page)
+        maintenance = Maintenance._from_rs(exo.runstatus, res["results"][0], page)
 
         maintenance.add_event(description="Stopping server", status="in-progress")
         maintenance.add_event(description="Upgrading memory")
@@ -56,7 +56,7 @@ class TestRunstatusPageMaintenance:
         assert res["results"][2]["status"] == "in-progress"
 
     def test_update(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_maintenance_title = "Database server upgrade"
         test_maintenance_title_edited = "Database server upgrade (edited)"
         test_maintenance_description = (
@@ -91,7 +91,7 @@ class TestRunstatusPageMaintenance:
         res = exo.runstatus._get(
             url="/pages/{p}/maintenances".format(p=page.name)
         ).json()
-        maintenance = Maintenance.from_rs(exo.runstatus, res["results"][0], page)
+        maintenance = Maintenance._from_rs(exo.runstatus, res["results"][0], page)
 
         maintenance.update(
             title=test_maintenance_title_edited,
@@ -118,7 +118,7 @@ class TestRunstatusPageMaintenance:
         assert maintenance.services == [test_maintenance_service_edited]
 
     def test_close(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_maintenance_title = "Database server upgrade"
         test_maintenance_description = (
             "We're upgrading the database server hardware to add more memory"
@@ -146,7 +146,7 @@ class TestRunstatusPageMaintenance:
         res = exo.runstatus._get(
             url="/pages/{p}/maintenances".format(p=page.name)
         ).json()
-        maintenance = Maintenance.from_rs(exo.runstatus, res["results"][0], page)
+        maintenance = Maintenance._from_rs(exo.runstatus, res["results"][0], page)
 
         maintenance.close("We're done here")
 
@@ -160,7 +160,7 @@ class TestRunstatusPageMaintenance:
         assert res["results"][0]["status"] == "completed"
 
     def test_properties(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         test_maintenance_title = "Database server upgrade"
         test_maintenance_description = (
             "We're upgrading the database server hardware to add more memory"
@@ -188,7 +188,7 @@ class TestRunstatusPageMaintenance:
         res = exo.runstatus._get(
             url="/pages/{p}/maintenances".format(p=page.name)
         ).json()
-        maintenance = Maintenance.from_rs(exo.runstatus, res["results"][0], page)
+        maintenance = Maintenance._from_rs(exo.runstatus, res["results"][0], page)
 
         for i in [1, 2, 3]:
             exo.runstatus._post(

--- a/tests/test_runstatus_service.py
+++ b/tests/test_runstatus_service.py
@@ -7,7 +7,7 @@ from exoscale.api.runstatus import *
 
 class TestRunstatusPageService:
     def test_delete(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         service_name = "a"
 
         exo.runstatus._post(
@@ -15,7 +15,7 @@ class TestRunstatusPageService:
         )
 
         res = exo.runstatus._get(url="/pages/{p}/services".format(p=page.name)).json()
-        service = Service.from_rs(exo.runstatus, res["results"][0], page=page)
+        service = Service._from_rs(exo.runstatus, res["results"][0], page=page)
 
         service.delete()
         assert service.id == None
@@ -24,7 +24,7 @@ class TestRunstatusPageService:
         assert len(res["results"]) == 0
 
     def test_properties(self, exo, runstatus_page):
-        page = Page.from_rs(exo.runstatus, runstatus_page())
+        page = Page._from_rs(exo.runstatus, runstatus_page())
         service_name = "a"
 
         exo.runstatus._post(
@@ -32,6 +32,6 @@ class TestRunstatusPageService:
         )
 
         res = exo.runstatus._get(url="/pages/{p}/services".format(p=page.name)).json()
-        service = Service.from_rs(exo.runstatus, res["results"][0], page=page)
+        service = Service._from_rs(exo.runstatus, res["results"][0], page=page)
 
         assert service.state == "operational"

--- a/tests/test_storage_bucket.py
+++ b/tests/test_storage_bucket.py
@@ -105,7 +105,7 @@ class TestStorageBucket:
                 assert i["Grantee"]["Type"] == "Group"
                 assert i["Grantee"]["URI"] == ACL_ALL_USERS
 
-        bucket_acp = AccessControlPolicy.from_s3(res)
+        bucket_acp = AccessControlPolicy._from_s3(res)
         bucket_acp.read = "ALL_USERS"
         bucket_acp.write = "AUTHENTICATED_USERS"
         bucket_acp.read_acp = "alice@example.net"

--- a/tests/test_storage_bucket_file.py
+++ b/tests/test_storage_bucket_file.py
@@ -35,7 +35,7 @@ class TestStorageBucketFile:
                 assert i["Grantee"]["Type"] == "Group"
                 assert i["Grantee"]["URI"] == ACL_ALL_USERS
 
-        f_acp = AccessControlPolicy.from_s3(res)
+        f_acp = AccessControlPolicy._from_s3(res)
         f_acp.read = "ALL_USERS"
         f_acp.write = "AUTHENTICATED_USERS"
         f_acp.read_acp = "alice@example.net"


### PR DESCRIPTION
Hide API `classmethod` functions from the public API to avoid users
being tempted to use them directly.