### PR TITLE
Require zone for zonal resources list/get calls 

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-s/root_disk/volume/

--- a/TODO
+++ b/TODO
@@ -1,0 +1,1 @@
+s/root_disk/volume/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,8 +36,8 @@ instance = exo.compute.create_instance(
     type=exo.compute.get_instance_type("medium"),
     template=list(
         exo.compute.list_instance_templates(
-            "Linux Ubuntu 18.04 LTS 64-bit",
-            zone_gva2))[0],
+            zone_gva2,
+            "Linux Ubuntu 18.04 LTS 64-bit")[0],
     root_disk_size=50,
     security_groups=[security_group_web],
     user_data="""#cloud-config

--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -427,7 +427,9 @@ class Instance(Resource):
             _list = self.compute.cs.listNics(virtualmachineid=self.id, fetch_list=True)
             default_nic = self._default_nic(_list)
             for a in default_nic.get("secondaryip", []):
-                yield self.compute.get_elastic_ip(zone=zone, address=a["ipaddress"])
+                yield self.compute.get_elastic_ip(
+                    zone=self.zone, address=a["ipaddress"]
+                )
         except CloudStackApiException as e:
             raise APIException(e.error["errortext"], e.error)
 
@@ -449,7 +451,9 @@ class Instance(Resource):
             for nic in _list:
                 if nic["isdefault"]:
                     continue
-                yield self.compute.get_private_network(zone=zone, id=nic["networkid"])
+                yield self.compute.get_private_network(
+                    zone=self.zone, id=nic["networkid"]
+                )
         except CloudStackApiException as e:
             raise APIException(e.error["errortext"], e.error)
 
@@ -1090,7 +1094,7 @@ class PrivateNetwork(Resource):
             latency.
         """
 
-        return self.compute.list_instances(zone=zone, networkid=self.id)
+        return self.compute.list_instances(zone=self.zone, networkid=self.id)
 
     def update(
         self, name=None, description=None, start_ip=None, end_ip=None, netmask=None

--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -427,7 +427,7 @@ class Instance(Resource):
             _list = self.compute.cs.listNics(virtualmachineid=self.id, fetch_list=True)
             default_nic = self._default_nic(_list)
             for a in default_nic.get("secondaryip", []):
-                yield self.compute.get_elastic_ip(address=a["ipaddress"])
+                yield self.compute.get_elastic_ip(zone=zone, address=a["ipaddress"])
         except CloudStackApiException as e:
             raise APIException(e.error["errortext"], e.error)
 
@@ -449,7 +449,7 @@ class Instance(Resource):
             for nic in _list:
                 if nic["isdefault"]:
                     continue
-                yield self.compute.get_private_network(id=nic["networkid"])
+                yield self.compute.get_private_network(zone=zone, id=nic["networkid"])
         except CloudStackApiException as e:
             raise APIException(e.error["errortext"], e.error)
 

--- a/tests/test_compute_anti_affinity_group.py
+++ b/tests/test_compute_anti_affinity_group.py
@@ -19,13 +19,3 @@ class TestComputeAntiAffinityGroup:
             name=anti_affinity_group_name, fetch_list=True
         )
         assert len(res) == 0
-
-    def test_properties(self, exo, aag, instance):
-        anti_affinity_group = AntiAffinityGroup._from_cs(exo.compute, aag())
-        instance = Instance._from_cs(
-            exo.compute, instance(anti_affinity_groups=[anti_affinity_group.id])
-        )
-
-        anti_affinity_group_instances = list(anti_affinity_group.instances)
-        assert len(anti_affinity_group_instances) == 1
-        assert anti_affinity_group_instances[0].name == instance.name


### PR DESCRIPTION
This change now requires a mandatory `zone` parameter for `(get|list)`_
calls to zone-local resources (i.e. Elastic IPs, Compute instances,
Compute instance templates and Private Networks).

Due to a limitation in the API, the `AntiAffinityGroup.instances`
property had to be removed.