### PR TITLE
Fix unhandled exceptions in get_* functions

### DIFF
--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -1615,6 +1615,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(anti_affinity_groups) == 0:
             raise ResourceNotFoundError
@@ -1726,6 +1728,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(elastic_ips) == 0:
             raise ResourceNotFoundError
@@ -1848,6 +1852,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(instances) == 0:
             raise ResourceNotFoundError
@@ -1946,6 +1952,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(instance_templates) == 0:
             raise ResourceNotFoundError
@@ -1990,6 +1998,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(instance_types) == 0:
             raise ResourceNotFoundError
@@ -2068,6 +2078,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(private_networks) == 0:
             raise ResourceNotFoundError
@@ -2133,6 +2145,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(security_groups) == 0:
             raise ResourceNotFoundError
@@ -2210,6 +2224,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(ssh_keys) == 0:
             raise ResourceNotFoundError
@@ -2254,6 +2270,8 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         if len(zones) == 0:
             raise ResourceNotFoundError

--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -1615,8 +1615,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(anti_affinity_groups) == 0:
             raise ResourceNotFoundError
@@ -1728,8 +1727,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(elastic_ips) == 0:
             raise ResourceNotFoundError
@@ -1852,8 +1850,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(instances) == 0:
             raise ResourceNotFoundError
@@ -1952,8 +1949,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(instance_templates) == 0:
             raise ResourceNotFoundError
@@ -1998,8 +1994,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(instance_types) == 0:
             raise ResourceNotFoundError
@@ -2078,8 +2073,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(private_networks) == 0:
             raise ResourceNotFoundError
@@ -2145,8 +2139,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(security_groups) == 0:
             raise ResourceNotFoundError
@@ -2224,8 +2217,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(ssh_keys) == 0:
             raise ResourceNotFoundError
@@ -2270,8 +2262,7 @@ class ComputeAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         if len(zones) == 0:
             raise ResourceNotFoundError

--- a/exoscale/api/dns.py
+++ b/exoscale/api/dns.py
@@ -310,6 +310,8 @@ class DnsAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
+            else:
+                raise e
 
         for domain in domains:
             if (name and domain.name == name) or (id and domain.id == id):

--- a/exoscale/api/dns.py
+++ b/exoscale/api/dns.py
@@ -310,8 +310,7 @@ class DnsAPI(API):
         except APIException as e:
             if "does not exist" in e.error["errortext"]:
                 raise ResourceNotFoundError
-            else:
-                raise e
+            raise
 
         for domain in domains:
             if (name and domain.name == name) or (id and domain.id == id):


### PR DESCRIPTION
This change fixes bugs in the `get_*` functions, where upon exception
only those matching "resource not found" error message would be raised
but any other would be silently discarded.