### PR TITLE
compute: add Instance creation date

### DIFF
--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -340,6 +340,7 @@ class Instance(Resource):
     Attributes:
         id (str): the instance unique identifier
         name (str): the instance hostname/display name
+        creation_date (datetime.datetime): the instance creation date
         zone (Zone): the zone in which the instance is located
         type (InstanceType): the instance type
         template (InstanceTemplate): the instance template
@@ -355,6 +356,7 @@ class Instance(Resource):
     res = attr.ib(repr=False)
     id = attr.ib()
     name = attr.ib()
+    creation_date = attr.ib(repr=False)
     zone = attr.ib(repr=False)
     type = attr.ib(repr=False)
     template = attr.ib(repr=False)
@@ -380,6 +382,7 @@ class Instance(Resource):
             res,
             id=res["id"],
             name=res["displayname"],
+            creation_date=datetime.strptime(res["created"], "%Y-%m-%dT%H:%M:%S%z"),
             zone=zone,
             type=compute.get_instance_type(id=res["serviceofferingid"]),
             template=compute.get_instance_template(zone, id=res["templateid"]),
@@ -802,6 +805,7 @@ class Instance(Resource):
         self.res = None
         self.id = None
         self.name = None
+        self.creation_date = None
         self.zone = None
         self.type = None
         self.template = None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 filterwarnings =
     # https://github.com/boto/boto3/issues/1615
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working:DeprecationWarning
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -3,6 +3,7 @@
 
 import pytest
 from cs import CloudStackApiException
+from datetime import datetime, timedelta
 from exoscale.api import ResourceNotFoundError
 from exoscale.api.compute import *
 from .conftest import _random_str
@@ -170,6 +171,9 @@ class TestCompute:
         )
         assert instance.id != ""
         assert instance.name == instance_name
+        assert datetime.now() - instance.creation_date.replace(tzinfo=None) < timedelta(
+            minutes=2
+        )
         assert instance.zone.id == zone.id
         assert instance.type.id == instance_type.id
         assert instance.template.id == instance_template.id

--- a/tests/test_compute_instance.py
+++ b/tests/test_compute_instance.py
@@ -96,10 +96,10 @@ class TestComputeInstance:
         instance = Instance._from_cs(exo.compute, instance())
 
         # FIXME: attach the EIP using exo.compute.cs.addIpToNic:
-        #res = exo.compute.cs.listNics(virtualmachineid=instance.id, fetch_list=True)
-        #exo.compute.cs.addIpToNic(
+        # res = exo.compute.cs.listNics(virtualmachineid=instance.id, fetch_list=True)
+        # exo.compute.cs.addIpToNic(
         #    nicid=instance._default_nic(res)["id"], ipaddress=elastic_ip.address
-        #)
+        # )
         instance.attach_elastic_ip(elastic_ip=elastic_ip)
 
         res = exo.compute.cs.listNics(virtualmachineid=instance.id, fetch_list=True)

--- a/tests/test_compute_instance.py
+++ b/tests/test_compute_instance.py
@@ -95,6 +95,11 @@ class TestComputeInstance:
         elastic_ip = ElasticIP._from_cs(exo.compute, eip())
         instance = Instance._from_cs(exo.compute, instance())
 
+        # FIXME: attach the EIP using exo.compute.cs.addIpToNic:
+        #res = exo.compute.cs.listNics(virtualmachineid=instance.id, fetch_list=True)
+        #exo.compute.cs.addIpToNic(
+        #    nicid=instance._default_nic(res)["id"], ipaddress=elastic_ip.address
+        #)
         instance.attach_elastic_ip(elastic_ip=elastic_ip)
 
         res = exo.compute.cs.listNics(virtualmachineid=instance.id, fetch_list=True)


### PR DESCRIPTION
This change introduces a new `api.compute.Instance` class attribute
`creation_date`.