### PR TITLE
The EIP description field is optional

### DIFF
--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -107,7 +107,7 @@ class ElasticIP(Resource):
             id=res["id"],
             zone=zone,
             address=res["ipaddress"],
-            description=res["description"],
+            description=res.get("description", ""),
             healthcheck_mode=res.get("healthcheck", {}).get("mode", None),
             healthcheck_port=res.get("healthcheck", {}).get("port", None),
             healthcheck_path=res.get("healthcheck", {}).get("path", None),

--- a/tests/test_compute_elastic_ip.py
+++ b/tests/test_compute_elastic_ip.py
@@ -59,6 +59,14 @@ class TestComputeElasticIP:
         res = exo.compute.cs.queryReverseDnsForPublicIpAddress(id=elastic_ip.id)
         assert len(res["publicipaddress"]["reversedns"]) == 0
 
+    def test_description_is_optional(self, exo, eip):
+        response = eip()
+        # The eip() fixture has a description set - del'ing it here is much cheaper
+        # than writing a new fixture just for this particular case.
+        del response['description']
+        elastic_ip = ElasticIP._from_cs(exo.compute, response)
+        assert elastic_ip.description == ""
+
     def test_update(self, exo, eip, test_description):
         elastic_ip = ElasticIP._from_cs(exo.compute, eip())
         description_edited = test_description + " (edited)"


### PR DESCRIPTION
If the description was never set on an EIP, the field is not part of the
returned structure.