### PR TITLE
Instance pool: add the instance_user_data attribute

### DIFF
--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -1080,6 +1080,8 @@ class InstancePool(Resource):
             pool
         instance_template (InstanceTemplate): the template to be used when this instance
             pool creates new instances.
+        instance_user_data (InstanceTemplate): The instances user data, in base64
+            pool creates new instances.
         instance_volume_size (int): the storage volume capacity in bytes to set when
             this Instance Pool creates new instances.
     """
@@ -1092,6 +1094,7 @@ class InstancePool(Resource):
     size = attr.ib(repr=False)
     instance_type = attr.ib(repr=False)
     instance_template = attr.ib(repr=False)
+    instance_user_data = attr.ib(repr=False)
     instance_volume_size = attr.ib(repr=False)
     description = attr.ib(default=None, repr=False)
 
@@ -1110,6 +1113,7 @@ class InstancePool(Resource):
             size=res["size"],
             instance_type=compute.get_instance_type(id=res["serviceofferingid"]),
             instance_template=compute.get_instance_template(zone, id=res["templateid"]),
+            instance_user_data=res.get("userdata"),
             instance_volume_size=res["rootdisksize"],
         )
 
@@ -1259,6 +1263,8 @@ class InstancePool(Resource):
         if instance_template is not None:
             self.instance_template = instance_template
 
+        if instance_user_data_content:
+            self.instance_user_data = instance_user_data_content
         if instance_volume_size is not None:
             self.instance_volume_size = instance_volume_size
 
@@ -1293,6 +1299,7 @@ class InstancePool(Resource):
         self.size = None
         self.instance_type = None
         self.instance_template = None
+        self.instance_user_data = None
         self.instance_volume_size = None
 
 

--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -1080,8 +1080,8 @@ class InstancePool(Resource):
             pool
         instance_template (InstanceTemplate): the template to be used when this instance
             pool creates new instances.
-        instance_user_data (InstanceTemplate): The instances user data, in base64
-            pool creates new instances.
+        instance_user_data (InstanceTemplate): The base64-encoded instances user
+            data, when the Instance Pool creates new instances
         instance_volume_size (int): the storage volume capacity in bytes to set when
             this Instance Pool creates new instances.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,11 @@ def test_instance_template_id():
 
 
 @pytest.fixture(autouse=True, scope="module")
+def test_instance_user_data():
+    return "#cloud-config"
+
+
+@pytest.fixture(autouse=True, scope="module")
 def test_reverse_dns():
     return "python.exoscale.com."
 
@@ -204,6 +209,7 @@ def instance_pool(
     test_description,
     test_instance_service_offering_id,
     test_instance_template_id,
+    test_instance_user_data,
 ):
     instance_pools = []
 
@@ -223,6 +229,7 @@ def instance_pool(
             size=size,
             serviceofferingid=instance_type_id,
             templateid=instance_template_id,
+            user_data=test_instance_user_data,
         )
 
         if teardown:

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from base64 import b64decode
 from cs import CloudStackApiException
 from datetime import datetime, timedelta
 from time import sleep
@@ -335,6 +336,7 @@ class TestCompute:
         test_description,
         test_instance_service_offering_id,
         test_instance_template_id,
+        test_instance_user_data,
     ):
         zone = Zone._from_cs(zone("ch-gva-2"))
         instance_pool_name = "-".join([test_prefix, _random_str()])
@@ -358,6 +360,7 @@ class TestCompute:
             instance_security_groups=[security_group],
             instance_private_networks=[private_network],
             instance_ssh_key=ssh_key,
+            instance_user_data=test_instance_user_data,
         )
 
         [actual_instance_pool] = exo.compute.cs.getInstancePool(
@@ -378,6 +381,14 @@ class TestCompute:
         assert actual_instance_pool["templateid"] == instance_template.id
         assert instance_pool.instance_volume_size == 20
         assert actual_instance_pool["rootdisksize"] == 20
+        assert (
+            b64decode(instance_pool.instance_user_data).decode("utf-8")
+            == test_instance_user_data
+        )
+        assert (
+            b64decode(actual_instance_pool["userdata"]).decode("utf-8")
+            == test_instance_user_data
+        )
 
         exo.compute.cs.destroyInstancePool(id=instance_pool.id, zoneid=zone.id)
 


### PR DESCRIPTION
This attribute contains the user_data (in base64) of the instance pool.