### PR TITLE
storage: fix failing tests

### DIFF
--- a/exoscale/api/storage.py
+++ b/exoscale/api/storage.py
@@ -105,7 +105,7 @@ class AccessControlPolicy(Resource):
 
     @classmethod
     def _from_s3(cls, res):
-        acp = cls(res, owner=res["Owner"]["ID"])
+        acp = cls(res, owner=res["Owner"]["DisplayName"])
 
         for i in res["Grants"]:
             if i["Permission"] == "FULL_CONTROL":
@@ -173,7 +173,7 @@ class AccessControlPolicy(Resource):
         """
 
         if grantee["Type"] == "CanonicalUser":
-            return grantee["ID"]
+            return grantee["DisplayName"]
         else:
             if grantee["URI"] == ACL_ALL_USERS:
                 return "ALL_USERS"

--- a/tests/test_storage_bucket.py
+++ b/tests/test_storage_bucket.py
@@ -3,6 +3,7 @@
 
 import pytest
 from exoscale.api.storage import *
+from time import sleep
 
 
 class TestStorageBucket:
@@ -197,6 +198,12 @@ class TestStorageBucket:
                 ]
             },
         )
+
+        # Retrieving the bucket ACL policy immediately after having set it can trigger
+        # a race condition at SOS level due to eventual consistency data store, so as
+        # a workaround we wait for a bit before getting our ACL policy back.
+        sleep(3)
+
         acp = bucket.acl
         assert acp.full_control == "alice@example.net"
         assert acp.read == "ALL_USERS"
@@ -218,6 +225,12 @@ class TestStorageBucket:
                 ]
             },
         )
+
+        # Retrieving the CORS configuration immediately after having set it can trigger
+        # a race condition at SOS level due to eventual consistency data store, so as
+        # a workaround we wait for a bit before getting our CORS configuration back.
+        sleep(3)
+
         cors = list(bucket.cors)
         assert len(cors) == 1
         assert cors[0].allowed_headers == ["*"]


### PR DESCRIPTION
This change fixes the storage storage bucket/files ACL management
following a change API-side, and fixes tests failing sporadically due to
API-side eventual consistency storage race conditions.