### PR TITLE
Make HTTP session retry policy use configurable

### DIFF
--- a/exoscale/__init__.py
+++ b/exoscale/__init__.py
@@ -175,7 +175,6 @@ class Exoscale:
             "key": self.api_key,
             "secret": self.api_secret,
             "max_retries": max_retries,
-            "trace": trace,
         }
         if storage_api_endpoint is not None:
             kwargs["endpoint"] = storage_api_endpoint

--- a/exoscale/__init__.py
+++ b/exoscale/__init__.py
@@ -36,6 +36,7 @@ class Exoscale:
         iam_api_endpoint (str): an alternative Exoscale IAM API endpoint
         storage_zone (str): an Exoscale Storage zone
         runstatus_api_endpoint (str): an alternative Exoscale Runstatus API endpoint
+        max_retries (int): the API HTTP session retry policy number of retries to allow
         trace (bool): API requests/responses tracing flag
 
     Attributes:
@@ -60,6 +61,7 @@ class Exoscale:
         storage_zone=None,
         runstatus_api_endpoint=None,
         iam_api_endpoint=None,
+        max_retries=3,
         trace=False,
     ):
         # Load settings from a configuration file profile
@@ -149,29 +151,54 @@ class Exoscale:
         self.api_key = api_key
         self.api_secret = api_secret
 
-        kwargs = {"key": self.api_key, "secret": self.api_secret, "trace": trace}
+        kwargs = {
+            "key": self.api_key,
+            "secret": self.api_secret,
+            "max_retries": max_retries,
+            "trace": trace,
+        }
         if compute_api_endpoint is not None:
             kwargs["endpoint"] = compute_api_endpoint
         self.compute = ComputeAPI(**kwargs)
 
-        kwargs = {"key": self.api_key, "secret": self.api_secret, "trace": trace}
+        kwargs = {
+            "key": self.api_key,
+            "secret": self.api_secret,
+            "max_retries": max_retries,
+            "trace": trace,
+        }
         if dns_api_endpoint is not None:
             kwargs["endpoint"] = dns_api_endpoint
         self.dns = DnsAPI(**kwargs)
 
-        kwargs = {"key": self.api_key, "secret": self.api_secret}
+        kwargs = {
+            "key": self.api_key,
+            "secret": self.api_secret,
+            "max_retries": max_retries,
+            "trace": trace,
+        }
         if storage_api_endpoint is not None:
             kwargs["endpoint"] = storage_api_endpoint
         if storage_zone is not None:
             kwargs["zone"] = storage_zone
         self.storage = StorageAPI(**kwargs)
 
-        kwargs = {"key": self.api_key, "secret": self.api_secret, "trace": trace}
+        kwargs = {
+            "key": self.api_key,
+            "secret": self.api_secret,
+            "max_retries": max_retries,
+            "trace": trace,
+        }
         if runstatus_api_endpoint is not None:
             kwargs["endpoint"] = runstatus_api_endpoint
         self.runstatus = RunstatusAPI(**kwargs)
 
-        kwargs = {"key": self.api_key, "secret": self.api_secret, "trace": trace}
+        kwargs = {
+            "key": self.api_key,
+            "secret": self.api_secret,
+            "max_retries": max_retries,
+            "trace": trace,
+        }
         if iam_api_endpoint is not None:
             kwargs["endpoint"] = iam_api_endpoint
         self.iam = IamAPI(**kwargs)

--- a/exoscale/api/__init__.py
+++ b/exoscale/api/__init__.py
@@ -38,7 +38,7 @@ class API(object):
     secret = attr.ib(repr=False)
     trace = attr.ib(default=False, repr=False)
     session = attr.ib(default=requests.Session(), repr=False)
-    max_retry = attr.ib(default=3, repr=False)
+    max_retries = attr.ib(default=3, repr=False)
     retry_backoff_factor = attr.ib(default=0.3, repr=False)
 
     def __attrs_post_init__(self):
@@ -62,7 +62,7 @@ class API(object):
 
         adapter = HTTPAdapter(
             max_retries=Retry(
-                total=self.max_retry,
+                total=self.max_retries,
                 backoff_factor=self.retry_backoff_factor,
                 status_forcelist=None,
             )

--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -1797,13 +1797,25 @@ class ComputeAPI(API):
         key (str): the Compute API key
         secret (str): the Compute API secret
         endpoint (str): the Compute API endpoint
+        max_retries (int): the API HTTP session retry policy number of retries to allow
         trace (bool): API request/response tracing flag
     """
 
     def __init__(
-        self, key, secret, endpoint="https://api.exoscale.com/v1", trace=False
+        self,
+        key,
+        secret,
+        endpoint="https://api.exoscale.com/v1",
+        max_retries=None,
+        trace=False,
     ):
-        super().__init__(endpoint, key, secret, trace)
+        super().__init__(
+            endpoint=endpoint,
+            key=key,
+            secret=secret,
+            max_retries=max_retries,
+            trace=trace,
+        )
 
         self.cs = CloudStack(
             key=key,

--- a/exoscale/api/dns.py
+++ b/exoscale/api/dns.py
@@ -230,13 +230,25 @@ class DnsAPI(API):
         key (str): the DNS API key
         secret (str): the DNS API secret
         endpoint (str): the DNS API endpoint
+        max_retries (int): the API HTTP session retry policy number of retries to allow
         trace (bool): API request/response tracing flag
     """
 
     def __init__(
-        self, key, secret, endpoint="https://api.exoscale.com/v1", trace=False
+        self,
+        key,
+        secret,
+        endpoint="https://api.exoscale.com/v1",
+        max_retries=None,
+        trace=False,
     ):
-        super().__init__(endpoint, key, secret, trace)
+        super().__init__(
+            endpoint=endpoint,
+            key=key,
+            secret=secret,
+            max_retries=max_retries,
+            trace=trace,
+        )
 
         self.cs = CloudStack(
             key=key,

--- a/exoscale/api/iam.py
+++ b/exoscale/api/iam.py
@@ -71,13 +71,25 @@ class IamAPI(API):
         key (str): the API key unique identifier
         secret (str): the IAM API secret
         endpoint (str): the IAM API endpoint
+        max_retries (int): the API HTTP session retry policy number of retries to allow
         trace (bool): API request/response tracing flag
     """
 
     def __init__(
-        self, key, secret, endpoint="https://api.exoscale.com/compute", trace=False
+        self,
+        key,
+        secret,
+        endpoint="https://api.exoscale.com/compute",
+        max_retries=None,
+        trace=False,
     ):
-        super().__init__(endpoint, key, secret, trace)
+        super().__init__(
+            endpoint=endpoint,
+            key=key,
+            secret=secret,
+            max_retries=max_retries,
+            trace=trace,
+        )
 
         self.cs = CloudStack(
             key=key,

--- a/exoscale/api/runstatus.py
+++ b/exoscale/api/runstatus.py
@@ -697,11 +697,25 @@ class RunstatusAPI(API):
         key (str): the Runstatus API key
         secret (str): the Runstatus API secret
         endpoint (str): the Runstatus API endpoint
+        max_retries (int): the API HTTP session retry policy number of retries to allow
         trace (bool): API request/response tracing flag
     """
 
-    def __init__(self, key, secret, endpoint="https://api.runstatus.com", trace=False):
-        super().__init__(endpoint, key, secret, trace)
+    def __init__(
+        self,
+        key,
+        secret,
+        endpoint="https://api.runstatus.com",
+        max_retries=None,
+        trace=False,
+    ):
+        super().__init__(
+            endpoint=endpoint,
+            key=key,
+            secret=secret,
+            max_retries=max_retries,
+            trace=trace,
+        )
 
         self.auth = ExoscaleAuth(self.key, self.secret)
 

--- a/exoscale/api/storage.py
+++ b/exoscale/api/storage.py
@@ -711,15 +711,19 @@ class StorageAPI(API):
         secret (str): the Storage API secret
         endpoint (str): the Storage API endpoint
         zone (str): the Storage zone
+        max_retries (int): the API HTTP session retry policy number of retries to allow
         trace (bool): API request/response tracing flag
     """
 
-    def __init__(self, key, secret, endpoint=None, zone=None):
+    def __init__(self, key, secret, endpoint=None, zone=None, max_retries=None):
         self.zone = _DEFAULT_ZONE if zone is None else zone
         endpoint = (
             "https://sos-{}.exo.io".format(self.zone) if endpoint is None else endpoint
         )
-        super().__init__(endpoint, key, secret)
+        max_retries = 3 if max_retries is None else max_retries
+        super().__init__(
+            endpoint=endpoint, key=key, secret=secret, max_retries=max_retries,
+        )
 
         if self.zone is None:
             raise ValueError("no storage zone specified")
@@ -730,7 +734,7 @@ class StorageAPI(API):
             endpoint_url=self.endpoint,
             aws_access_key_id=key,
             aws_secret_access_key=secret,
-            config=botocore.client.Config(retries=dict(max_attempts=1)),
+            config=botocore.client.Config(retries={"max_attempts": self.max_retries}),
         )
 
     def __repr__(self):


### PR DESCRIPTION
This change exposes a configurable `max_retries` parameter enabling
users to adjust the number of retries with the API HTTP client session.