### PR TITLE
compute: add support for EIP HTTPS health checking

### DIFF
--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -63,13 +63,15 @@ class TestCompute:
 
     def test_create_elastic_ip(self, exo, zone, test_description):
         zone = Zone._from_cs(zone("ch-gva-2"))
-        healthcheck_mode = "http"
-        healthcheck_port = 80
+        healthcheck_mode = "https"
+        healthcheck_port = 443
         healthcheck_path = "/health"
         healthcheck_interval = 5
         healthcheck_timeout = 3
         healthcheck_strikes_ok = 2
         healthcheck_strikes_fail = 1
+        healthcheck_tls_sni = "example.net"
+        healthcheck_tls_skip_verify = True
 
         elastic_ip = exo.compute.create_elastic_ip(
             zone=zone,
@@ -81,6 +83,8 @@ class TestCompute:
             healthcheck_timeout=healthcheck_timeout,
             healthcheck_strikes_ok=healthcheck_strikes_ok,
             healthcheck_strikes_fail=healthcheck_strikes_fail,
+            healthcheck_tls_sni=healthcheck_tls_sni,
+            healthcheck_tls_skip_verify=healthcheck_tls_skip_verify,
         )
         assert elastic_ip.zone.id == zone.id
         assert elastic_ip.zone.name == zone.name
@@ -93,6 +97,8 @@ class TestCompute:
         assert elastic_ip.healthcheck_timeout == healthcheck_timeout
         assert elastic_ip.healthcheck_strikes_ok == healthcheck_strikes_ok
         assert elastic_ip.healthcheck_strikes_fail == healthcheck_strikes_fail
+        assert elastic_ip.healthcheck_tls_sni == healthcheck_tls_sni
+        assert elastic_ip.healthcheck_tls_skip_verify == healthcheck_tls_skip_verify
 
         exo.compute.cs.disassociateIpAddress(id=elastic_ip.id)
 

--- a/tests/test_compute_elastic_ip.py
+++ b/tests/test_compute_elastic_ip.py
@@ -70,13 +70,15 @@ class TestComputeElasticIP:
     def test_update(self, exo, eip, test_description):
         elastic_ip = ElasticIP._from_cs(exo.compute, eip())
         description_edited = test_description + " (edited)"
-        healthcheck_mode = "http"
-        healthcheck_port = 80
+        healthcheck_mode = "https"
+        healthcheck_port = 443
         healthcheck_path = "/test"
         healthcheck_interval = 5
         healthcheck_timeout = 3
         healthcheck_strikes_ok = 2
         healthcheck_strikes_fail = 1
+        healthcheck_tls_sni = "example.net"
+        healthcheck_tls_skip_verify = True
 
         elastic_ip.update(
             description=description_edited,
@@ -87,6 +89,8 @@ class TestComputeElasticIP:
             healthcheck_timeout=healthcheck_timeout,
             healthcheck_strikes_ok=healthcheck_strikes_ok,
             healthcheck_strikes_fail=healthcheck_strikes_fail,
+            healthcheck_tls_sni=healthcheck_tls_sni,
+            healthcheck_tls_skip_verify=healthcheck_tls_skip_verify,
         )
 
         [res] = exo.compute.cs.listPublicIpAddresses(id=elastic_ip.id, fetch_list=True)
@@ -107,6 +111,10 @@ class TestComputeElasticIP:
         assert elastic_ip.healthcheck_strikes_ok == healthcheck_strikes_ok
         assert res["healthcheck"]["strikes-fail"] == healthcheck_strikes_fail
         assert elastic_ip.healthcheck_strikes_fail == healthcheck_strikes_fail
+        assert res["healthcheck"]["tls-sni"] == healthcheck_tls_sni
+        assert elastic_ip.healthcheck_tls_sni == healthcheck_tls_sni
+        assert res["healthcheck"]["tls-skip-verify"] == healthcheck_tls_skip_verify
+        assert elastic_ip.healthcheck_tls_skip_verify == healthcheck_tls_skip_verify
 
     def test_delete(self, exo, eip, instance):
         elastic_ip = ElasticIP._from_cs(exo.compute, eip(teardown=False))


### PR DESCRIPTION
This change adds support for managed Elastic IP HTTPS health checking.