### PR TITLE
compute: add Anti-Affinity Groups support to Instance Pools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+    - '**'
+    paths-ignore:
+    - '**.md'
+    - '**.rst'
+    - '**.txt'
+    tags-ignore:
+    - 'v**' # Don't run CI tests on release tags
 
 jobs:
   CI:

--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -1721,7 +1721,9 @@ class NetworkLoadBalancer(Resource):
         """
 
         res = self.compute._v2_request(
-            "GET", "/load-balancer/" + self.id, self.zone.name,
+            "GET",
+            "/load-balancer/" + self.id,
+            self.zone.name,
         )
 
         return res["state"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def exo():
 
 @pytest.fixture(autouse=True, scope="function")
 def zone(exo):
-    def _zone(name):
+    def _zone(name=_DEFAULT_ZONE_NAME):
         return exo.compute.cs.listZones(name=name, fetch_list=True)[0]
 
     return _zone
@@ -216,6 +216,9 @@ def instance_pool(
         size=1,
         instance_type_id=test_instance_service_offering_id,
         instance_template_id=test_instance_template_id,
+        security_groups=None,
+        anti_affinity_groups=None,
+        private_networks=None,
         teardown=True,
     ):
         instance_pool = exo.compute.cs.createInstancePool(
@@ -225,6 +228,9 @@ def instance_pool(
             size=size,
             serviceofferingid=instance_type_id,
             templateid=instance_template_id,
+            securitygroupids=security_groups,
+            affinitygroupids=anti_affinity_groups,
+            networkids=private_networks,
             user_data=test_instance_user_data,
         )
 


### PR DESCRIPTION
This change adds Anti-Affinity Group support to `compute.InstancePool`
resources, and add missing `compute.InstancePool.security_groups`
property.