### PR TITLE
Compute: don't crash when listing instances generated from templates

### DIFF
--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -4,17 +4,19 @@
 This submodule represents the Exoscale Compute API.
 """
 
-import attr
 import json
-import polling
-import requests
 import sys
 import time
-from . import API, Resource, APIException, ResourceNotFoundError, RequestError
 from base64 import b64encode
-from cs import CloudStack, CloudStackApiException
 from datetime import datetime
+
+import attr
+import polling
+import requests
+from cs import CloudStack, CloudStackApiException
 from exoscale_auth import ExoscaleV2Auth
+
+from . import API, APIException, RequestError, Resource, ResourceNotFoundError
 
 
 @attr.s
@@ -904,7 +906,7 @@ class InstanceTemplate(Resource):
             zone=zone,
             date=datetime.strptime(res["created"], "%Y-%m-%dT%H:%M:%S%z"),
             size=res["size"],
-            username=res["details"].get("username", None),
+            username=res.get("details", {}).get("username", None),
             ssh_key_enabled=res["sshkeyenabled"],
             password_reset_enabled=res["passwordenabled"],
         )
@@ -1721,9 +1723,7 @@ class NetworkLoadBalancer(Resource):
         """
 
         res = self.compute._v2_request(
-            "GET",
-            "/load-balancer/" + self.id,
-            self.zone.name,
+            "GET", "/load-balancer/" + self.id, self.zone.name
         )
 
         return res["state"]


### PR DESCRIPTION
Calling `exo.compute.list_instances()` crashes because (some?) instances generated from templates lack the `details` property:

```
{
     'checksum': '(redacted)',
     'created': '2021-02-15T11:38:19+0000',
     'crossZones': False,
     'directdownload': True,
     'displaytext': '',
     'format': 'QCOW2',
     'hypervisor': 'KVM',
     'id': '(redacted)',
     'isdynamicallyscalable': False,
     'isextractable': True,
     'isfeatured': False,
     'ispublic': False,
     'isready': True,
     'name': '(redacted)',
     'oscategoryid': '(redacted)',
     'oscategoryname': 'Other',
     'ostypeid': '(redacted)',
     'ostypename': 'Other (64-bit)',
     'passwordenabled': False,
     'size': 10737418240,
     'sshkeyenabled': False,
     'tags': [],
     'templatetype': 'USER',
     'zoneid': '1128bd56-b4d9-4ac6-a7b9-c715b187ce11',
     'zonename': 'ch-gva-2'
}
```

Proposed fix prevents the crash.
