### PR TITLE
compute: fix check in instance pool args

### DIFF
--- a/exoscale/api/compute.py
+++ b/exoscale/api/compute.py
@@ -3060,7 +3060,7 @@ class ComputeAPI(API):
         if instance_security_groups:
             data["security-groups"] = [{"id": i.id} for i in instance_security_groups]
 
-        if instance_security_groups:
+        if instance_private_networks:
             data["private-networks"] = [{"id": i.id} for i in instance_private_networks]
 
         if instance_ssh_key:


### PR DESCRIPTION
There seems to be an error when checking if `instance_private_networks` was passed as an argument for the `create_instance_pool` function. The current behavior makes `create_instance_pool` fail if `instance_security_groups` is set without setting `instance_private_networks` (as it tries to iterate over `None`). 

If this is intended behavior I apologize for this PR.