### PR TITLE
openapi action: enable pipefail

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -14,6 +14,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Fetch latest OpenAPI definition
+        shell: bash
         run: |-
           curl https://openapi-v2.exoscale.com/source.json | ./.sort-enums.py | jq > exoscale/openapi.json
       - name: Commit and push if changed


### PR DESCRIPTION
This should prevent github actions from committing an empty spec to the repo in case of an HTTP failure. Example previous occurrence:

https://github.com/exoscale/python-exoscale/actions/runs/6809578290/job/18516145538

From the actions docs:

> When shell: bash is specified, -o pipefail is also applied to enforce early exit from pipelines that generate a non-zero exit status.