### PR TITLE
client: improve init

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.9.0 (unreleased)
+~~~~~~~~~~~~~~~~~~
+
+``exoscale.api.v2.Client`` improvements:
+
+* Client initialization accepts two signatures: ``Client(key, secret, zone)`` for
+  typical use and ``Client(key, secret, url)`` when needing to target another
+  endpoint than the public endpoint template.
+
 0.8.0 (2023-05-11)
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/v2.rst
+++ b/docs/v2.rst
@@ -1,13 +1,16 @@
 V2 API bindings
 ===============
 
-This modules contains a low-level client targeting the Exoscale `OpenAPI-based
-V2 API`_. This client is dynamically generated from the OpenAPI definition
-shipped with the package.
+..
+   If you are reading this: most of the V2 API client being dynamically
+   generated, its documentation is generated as well. In order to browse it:
 
-.. _OpenAPI-based V2 API: https://openapi-v2.exoscale.com/
+   - See the generated documentation at
+     https://exoscale.github.io/python-exoscale/v2.html, or
 
-.. autoclass:: exoscale.api.v2.Client
-   :members:
+   - run ``make html`` from the root of the source tree and open
+     build/html/v2.html.
+
+.. automodule:: exoscale.api.v2
+   :members: Client
    :undoc-members:
-   :special-members: __init__

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,22 @@
+import pytest
+
 from exoscale.api.v2 import Client
 
 
 def test_client_creation():
     c = Client("key", "secret", zone="at-vie-1")
+    assert hasattr(c, "list_zones")
+
+    # incorrect zone
+    with pytest.raises(TypeError) as exc:
+        Client("key", "secret", zone="us-east-1")
+    assert "Invalid zone" in str(exc.value)
+
+    # unhandled kwarg
+    with pytest.raises(TypeError) as exc:
+        Client("key", "secret", region="ch-dk-2")
+    assert "Unhandled keyword argument" in str(exc.value)
+
+    # create with custom URL
+    c = Client("key", "secret", url="http://localhost:8000/v2")
     assert hasattr(c, "list_zones")


### PR DESCRIPTION
Following the egoscale v3 design, client can be initialized with either:

- credentials + a zone name
- credentials + a full endpoint