### PR TITLE
wip(doc): Try to add the attributes of the return objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 dist
 /.vscode
 .tox
+.idea/
+Dockerfile

--- a/exoscale/api/v2.py
+++ b/exoscale/api/v2.py
@@ -161,7 +161,25 @@ def _return_docstring(operation):
     ]
     if "$ref" in return_schema:
         ref = _get_ref(return_schema["$ref"])
-        if "description" in ref:
+        if "properties" in ref:
+            body = {}
+            for name, prop in ref["properties"].items():
+                if "$ref" in prop:
+                    ref = _get_ref(prop["$ref"])
+                    item = ref
+                else:
+                    item = prop
+                typ = _type_translations[item["type"]]
+                desc = prop.get("description")
+                if "enum" in item:
+                    choices = "``, ``".join(map(repr, item["enum"]))
+                    desc += f". Values are ``{choices}``"
+                suffix = f": {desc}" if desc else ""
+                normalized_name = name.replace("-", "_")
+                body[normalized_name] = f"{normalized_name} ({typ}){suffix}."
+
+            doc = "\n\n        ".join(body.values())
+        elif "description" in ref:
             doc = f'{_type_translations[ref["type"]]}: {ref["description"]}.'
         else:
             doc = _type_translations[ref["type"]]


### PR DESCRIPTION
Dear Exoscale Team, 

The purpose of this MR is to have the different attributes of the returned object of each function in the python documentation directly instead of having only `dict` and need to go to the [openapi documentation](https://openapi-v2.exoscale.com) to get the aforementioned attributes.

I took part of the code from `_create_operation_call` which gave me the following string for example with the `delete-load-balancer` operation (which is what I wanted). 

```
id (str): Operation ID.

        reason (str): Operation failure reason. Values are ``'busy'``, ``'conflict'``, ``'fault'``, ``'forbidden'``, ``'incorrect'``, ``'interrupted'``, ``'not-found'``, ``'partial'``, ``'unavailable'``, ``'unknown'``, ``'unsupported'``.

        reference (dict): Related resource reference.

        message (str): Operation message.

        state (str): Operation status. Values are ``'failure'``, ``'pending'``, ``'success'``, ``'timeout'``.
```

However, as you can see on the following picture, the first `id (str)` is going to the `Returns Type` (it seems the doc is parsing the string and splitting the string at the first colon)

![image](https://github.com/exoscale/python-exoscale/assets/42201667/2462d533-7632-4739-99ce-6ec4c40eb109)

I have some difficulties to understand the Sphinx documentation and that is something I don't know at all. Therefore, I'm asking for your help, if you could help understand where the `Returns Type` is defined or how is it defined how to display it, is there a way to display all the attribute properly ??