### PR TITLE
fix: handle multiple path parameters

### DIFF
--- a/exoscale/api/v2.py
+++ b/exoscale/api/v2.py
@@ -129,6 +129,7 @@ class BaseClient:
 
         path = op["path"]
         query_params = {}
+        path_params = {}
         if parameters is None:
             parameters = {}
         for param in op["operation"].get("parameters", []):
@@ -138,10 +139,11 @@ class BaseClient:
             if name in parameters:
                 value = parameters[name]
                 if param["in"] == "path":
-                    # TODO validate
-                    path = path.format(**{name: value})
+                    path_params[name] = value
                 elif param["in"] == "query":
                     query_params[name] = value
+
+        path = path.format(**path_params)
 
         url = f"{self.endpoint}{path}"
 


### PR DESCRIPTION
When calling an API endpoint with multiple path parameters, it raised a `KeyError` because path parameters were handled one by one.

This PR fix this by handling query parameters the same as body parameters. It means looping through all parameters THEN formatting them for the endpoint URL.