### PR TITLE
fix(doc): Fix build of doc and return error on warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+# If there is an issue in the build process, for example import error in the "reading process" job of sphinx-build
+# It will only raise warning which won't make the job in the CI fail, but the HTML page will be empty.
+# Therefore, we add the "--fail-on-warning" option.
+SPHINXOPTS    ?= --fail-on-warning
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = docs
 BUILDDIR      = build

--- a/exoscale/api/v2.py
+++ b/exoscale/api/v2.py
@@ -167,7 +167,7 @@ class BaseClient:
             raise ExoscaleAPIAuthException(
                 f"Authentication error {response.status_code}: {response.text}"
             )
-        if response.status_code >= 400 and response.status_code < 500:
+        if 400 <= response.status_code < 500:
             raise ExoscaleAPIClientException(
                 f"Client error {response.status_code}: {response.text}"
             )
@@ -185,6 +185,7 @@ _type_translations = {
     "object": "dict",
     "array": "list",
     "boolean": "bool",
+    "number": "float",
 }
 
 


### PR DESCRIPTION
This fix the build of the documentation.

As you can see, the documentation is empty on prod: https://exoscale.github.io/python-exoscale/v2.html

This is because the build of the documentation failed in the [last CI](https://github.com/exoscale/python-exoscale/actions/runs/10698176406/job/29656979260), but Sphinx considered it as a warning. Therefore the job in the pipeline was not failing.

```
root@d662111d295e:/exo# make html
Running Sphinx v7.4.7
loading translations [en]... done
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 3 source files that are out of date
updating environment: [new config] 3 added, 0 changed, 0 removed
reading sources... [100%] v2
WARNING: autodoc: failed to import module 'v2' from module 'exoscale.api'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/sphinx/ext/autodoc/importer.py", line 143, in import_module
    return importlib.import_module(modname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/exo/exoscale/api/v2.py", line 371, in <module>
    Client = _create_client_class()
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/exo/exoscale/api/v2.py", line 364, in _create_client_class
    class_attributes[py_operation_name] = _create_operation_call(
                                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/exo/exoscale/api/v2.py", line 317, in _create_operation_call
    ret=_return_docstring(operation),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/exo/exoscale/api/v2.py", line 211, in _return_docstring
    typ = _type_translations[item["type"]]
          ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'number'

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... done
copying extra files... done
copying assets: done
writing output... [100%] v2
generating indices... done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.

```

For the job to fail in the pipeline in the future, I add the `--fail-on-warning` option.

I also fix the build by adding the missing type in the `_type_translations` dict.