### PR TITLE
Fix doc format

### DIFF
--- a/exoscale/api/v2.py
+++ b/exoscale/api/v2.py
@@ -38,7 +38,7 @@ Examples:
          'link': '/v2/sks-cluster/8561ee34-09f0-42da-a765-abde807f944b',
          'command': 'get-sks-cluster'}}
 
-    In case of a conflict between argument names and Python keywords, **kwargs syntax can be used:
+    In case of a conflict between argument names and Python keywords, ``**kwargs`` syntax can be used:
 
     >>> from exoscale.api.v2 import Client
     >>> c = Client("api-key", "api-secret", zone="ch-gva-2")


### PR DESCRIPTION
Fixes document builder error:
```
/home/runner/work/python-exoscale/python-exoscale/exoscale/api/v2.py:docstring of exoscale.api.v2:40: WARNING: Inline strong start-string without end-string. [docutils]
```