### PR TITLE
api: list-zones: do not send auth header

### DIFF
--- a/exoscale/api/generator.py
+++ b/exoscale/api/generator.py
@@ -166,9 +166,17 @@ class BaseClient:
             # TODO validate
             json["json"] = body
 
-        response = self.http_client.request(
-            method=op["verb"].upper(), url=url, params=query_params, **json
-        )
+        # list-zones returns public data but the server enforces IAM role policies
+        # on authenticated requests — restricted keys (e.g. DBaaS-only) get 403.
+        # Send the request without credentials so it always succeeds.
+        if operation_id == "list-zones":
+            response = requests.request(
+                method=op["verb"].upper(), url=url, params=query_params, **json
+            )
+        else:
+            response = self.http_client.request(
+                method=op["verb"].upper(), url=url, params=query_params, **json
+            )
 
         # Error handling
         if response.status_code == 403:


### PR DESCRIPTION
`/zone` is public but the server enforces IAM on authenticated requests, so a DBaaS-only key gets 403 for no reason.

In `_call_operation`, when the operation is `list-zones`, the request is sent via a plain `requests.request` without credentials. No IAM check fires and all zones come back.

**Snippet used to verify:**

```python
from exoscale.api.v2 import Client

client = Client(key=key, secret=secret, zone="ch-gva-2")
result = client.list_zones()
zones = result["zones"]
print(f"ok: {len(zones)} zones")
for z in zones:
    print(f"  - {z['name']}")
```

**Before** (master, DBaaS-only key):
```
exoscale.api.exceptions.ExoscaleAPIAuthException: Authentication error 403: {"message":"Invalid request signature"}
```

**After** (this branch, same key):
```
ok: 8 zones
  - ch-gva-2
  - ch-dk-2
  - at-vie-1
  - de-fra-1
  - bg-sof-1
  - de-muc-1
  - at-vie-2
  - hr-zag-1
```

Related: exoscale/egoscale#767, exoscale/exoscale-sdk-java#14

---

> [!NOTE]
> AI-assisted.
