### PR TITLE
fix(generator): handle list-typed nullable fields from upstream spec

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -21,6 +21,11 @@ jobs:
           curl https://api-ch-gva-2.exoscale.com/v2/openapi.json | ./.sort-enums.py | jq > exoscale/openapi.json
 
           curl https://partner-api.exoscale.com/v1.alpha/openapi.json | ./.sort-enums.py | jq > exoscale/partner-api.json
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Verify with tests
+        run: uv run pytest
       - name: Commit and push if changed
         run: |-
           git config user.name "Automated"

--- a/exoscale/api/generator.py
+++ b/exoscale/api/generator.py
@@ -52,6 +52,15 @@ _type_translations = {
 }
 
 
+def _translate_type(typ):
+    if isinstance(typ, list):
+        non_null = [t for t in typ if t != "null"]
+        if len(non_null) == 1:
+            return f"{_type_translations[non_null[0]]} | None"
+        return " | ".join(_type_translations[t] for t in non_null)
+    return _type_translations[typ]
+
+
 def _status_code_docstring(api_spec, operation, status_code):
     [ctype] = operation["responses"][status_code]["content"].keys()
     return_schema = operation["responses"][status_code]["content"][ctype][
@@ -71,7 +80,7 @@ def _status_code_docstring(api_spec, operation, status_code):
                     item = _ref
                 else:
                     item = prop
-                typ = _type_translations[item["type"]]
+                typ = _translate_type(item["type"])
                 desc = prop.get("description")
                 if "enum" in item:
                     choices = "``, ``".join(map(repr, item["enum"]))
@@ -87,11 +96,11 @@ def _status_code_docstring(api_spec, operation, status_code):
                 + "\n\n          * ".join([""] + list(body.values()))
             )
         elif "description" in ref:
-            doc = f"{_type_translations[ref['type']]}: {ref['description']}."
+            doc = f"{_translate_type(ref['type'])}: {ref['description']}."
         else:
-            doc = _type_translations[ref["type"]]
+            doc = _translate_type(ref["type"])
     else:
-        doc = _type_translations[return_schema["type"]]
+        doc = _translate_type(return_schema["type"])
     return doc
 
 
@@ -213,9 +222,9 @@ def _create_operation_call(
         name = param["name"]
         if "$ref" in param["schema"]:
             ref = _get_ref(api_spec, param["schema"]["$ref"])
-            typ = _type_translations[ref["type"]]
+            typ = _translate_type(ref["type"])
         else:
-            typ = _type_translations[param["schema"]["type"]]
+            typ = _translate_type(param["schema"]["type"])
         normalized_name = name.replace("-", "_")
         normalized_names[normalized_name] = name
         parameters[normalized_name] = f"{normalized_name} ({typ})."
@@ -236,7 +245,7 @@ def _create_operation_call(
                 item = ref
             else:
                 item = prop
-            typ = _type_translations[item["type"]]
+            typ = _translate_type(item["type"])
             desc = prop.get("description") or item.get("description")
             if "enum" in item:
                 choices = "``, ``".join(map(repr, item["enum"]))


### PR DESCRIPTION
The upstream Exoscale OpenAPI v2 spec now emits `type` as a list
for nullable fields, e.g. `"type": ["integer", "null"]`. The code
generator at `generator.py:74` assumed `type` is always a `str`,
causing `TypeError: unhashable type: `list`` on import.

**Before (master):** pytest collects 0 items, 2 errors

```
tests/test_client.py ▸ exoscale/api/v2.py:97 ▸ generator.py:74
  typ = _type_translations[item["type"]]
TypeError: cannot use "list" as a dict key (unhashable type: "list")
```

**After (fix):**

```
collected 16 items
tests/test_client.py ........                                        [ 50%]
tests/test_partner_client.py ........                                [100%]
============================== 16 passed in 0.08s ==============================
```

**Changes:**
- Added `_translate_type()` helper in `generator.py` that handles both
  `str` and `list` type values (list → `"int | None"`)
- Replaced all 7 direct `_type_translations[<expr>]` call sites with
  `_translate_type(<expr>)`
- Added `uv run pytest` step to `openapi.yaml` auto-update workflow so
  spec changes are verified before committing to master

> [!NOTE]
> AI-assisted for initial investigation and implementation.