### PR TITLE
ci: trigger CI after openapi spec updates + fix generator nullable type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,18 @@ name: CI
   push:
     branches:
       - '**'
+      - master
     paths-ignore:
       - '**.md'
       - '**.rst'
       - '**.txt'
     tags-ignore:
       - 'v**'  # Don't run CI tests on release tags
+  workflow_run:
+    workflows:
+      - 'Update bundled openapi definition'
+    types:
+      - completed
 
 jobs:
   tests:

--- a/exoscale/api/generator.py
+++ b/exoscale/api/generator.py
@@ -52,6 +52,14 @@ _type_translations = {
 }
 
 
+def _resolve_type(t):
+    if isinstance(t, list):
+        for candidate in t:
+            if candidate != "null":
+                return candidate
+    return t
+
+
 def _status_code_docstring(api_spec, operation, status_code):
     [ctype] = operation["responses"][status_code]["content"].keys()
     return_schema = operation["responses"][status_code]["content"][ctype][
@@ -71,7 +79,7 @@ def _status_code_docstring(api_spec, operation, status_code):
                     item = _ref
                 else:
                     item = prop
-                typ = _type_translations[item["type"]]
+                typ = _type_translations[_resolve_type(item["type"])]
                 desc = prop.get("description")
                 if "enum" in item:
                     choices = "``, ``".join(map(repr, item["enum"]))
@@ -87,11 +95,11 @@ def _status_code_docstring(api_spec, operation, status_code):
                 + "\n\n          * ".join([""] + list(body.values()))
             )
         elif "description" in ref:
-            doc = f"{_type_translations[ref['type']]}: {ref['description']}."
+            doc = f"{_type_translations[_resolve_type(ref['type'])]}: {ref['description']}."
         else:
-            doc = _type_translations[ref["type"]]
+            doc = _type_translations[_resolve_type(ref["type"])]
     else:
-        doc = _type_translations[return_schema["type"]]
+        doc = _type_translations[_resolve_type(return_schema["type"])]
     return doc
 
 
@@ -221,9 +229,9 @@ def _create_operation_call(
         name = param["name"]
         if "$ref" in param["schema"]:
             ref = _get_ref(api_spec, param["schema"]["$ref"])
-            typ = _type_translations[ref["type"]]
+            typ = _type_translations[_resolve_type(ref["type"])]
         else:
-            typ = _type_translations[param["schema"]["type"]]
+            typ = _type_translations[_resolve_type(param["schema"]["type"])]
         normalized_name = name.replace("-", "_")
         normalized_names[normalized_name] = name
         parameters[normalized_name] = f"{normalized_name} ({typ})."
@@ -244,7 +252,7 @@ def _create_operation_call(
                 item = ref
             else:
                 item = prop
-            typ = _type_translations[item["type"]]
+            typ = _type_translations[_resolve_type(item["type"])]
             desc = prop.get("description") or item.get("description")
             if "enum" in item:
                 choices = "``, ``".join(map(repr, item["enum"]))


### PR DESCRIPTION
Two changes:

1. **CI**: `.github/workflows/main.yml` triggers CI on completion of `Update bundled openapi definition` (the hourly job that pushes spec updates to master), plus an explicit `master` entry in `push.branches`. A bad spec update now fails CI instead of going silent.
2. **Generator**: `exoscale/api/generator.py` adds `_resolve_type()` to handle OpenAPI 3.1 nullable schemas like `"type": ["integer", "null"]`. The old code assumed `schema["type"]` was a string and died at import with `unhashable type: 'list'`, bricking the whole SDK. This is the breakage the CI hook above is meant to catch next time.

Verified on Python 3.10 to 3.14: 16 passed on every version. Output:

```
tests/test_client.py::test_client_creation PASSED                        [  6%]
tests/test_client.py::test_client_error_handling PASSED                  [ 12%]
tests/test_client.py::test_wait_interval PASSED                          [ 18%]
tests/test_client.py::test_operation_poll_failure PASSED                 [ 25%]
tests/test_client.py::test_operation_invalid_state PASSED                [ 31%]
tests/test_client.py::test_wait_time_success PASSED                      [ 37%]
tests/test_client.py::test_wait_time_poll_errors PASSED                  [ 43%]
tests/test_client.py::test_wait_time_failure PASSED                      [ 50%]
tests/test_partner_client.py::test_client_creation PASSED                [ 56%]
tests/test_partner_client.py::test_client_with_custom_url PASSED         [ 62%]
tests/test_partner_client.py::test_client_error_handling PASSED          [ 68%]
tests/test_partner_client.py::test_authentication PASSED                 [ 75%]
tests/test_partner_client.py::test_create_organization_with_structured_address PASSED [ 81%]
tests/test_partner_client.py::test_create_organization_with_optional_fields PASSED [ 87%]
tests/test_partner_client.py::test_create_organization_minimal_billing_address PASSED [ 93%]
tests/test_partner_client.py::test_list_organizations PASSED             [100%]

============================== 16 passed in 0.06s ==============================
```

> [!NOTE]
> AI-assisted for patch draft and this very PR description.