### PR TITLE
Generator handles 204 (without body)

### DIFF
--- a/exoscale/api/generator.py
+++ b/exoscale/api/generator.py
@@ -61,10 +61,14 @@ def _resolve_type(t):
 
 
 def _status_code_docstring(api_spec, operation, status_code):
-    [ctype] = operation["responses"][status_code]["content"].keys()
-    return_schema = operation["responses"][status_code]["content"][ctype][
-        "schema"
-    ]
+    response = operation["responses"][status_code]
+    # A bodyless response -- a 204, typically -- documents no content, and
+    # `_call_operation` returns None for it.
+    if "content" not in response:
+        return "None"
+
+    [ctype] = response["content"].keys()
+    return_schema = response["content"][ctype]["schema"]
     if "$ref" in return_schema:
         ref = _get_ref(api_spec, return_schema["$ref"])
         if (


### PR DESCRIPTION
Endpoints [delete-vpc, delete-subnet and delete-route][0] added in [Public API][1] introduce 204 responses which don't contain any body. This commit treats the "content" of response as optional thus preventing the generator to fail.

[0]: https://github.com/exoscale/python-exoscale/commit/088af84c149658ab339916d0d3465accf04c07c0
[1]: https://github.com/exoscale/public-api/commit/bcde348d1971898e53fe13ff248b2c0a3c6e276f